### PR TITLE
Rewrite typing.final to a dummy lambda in older python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,22 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/pelson/retrofy"
 
+[project.entry-points.multistage_build]
+# Declare automatic hooks for a multistage-build using project.
+post-build-wheel = "retrofy._pep517_hooks:compatibility_via_rewrite"
+post-build-editable = "retrofy._pep517_hooks:compatibility_via_import_hook"
+
 [tool.setuptools.packages.find]
 include = ["retrofy", "retrofy.*"]
 
 [tool.setuptools_scm]
 write_to = "retrofy/_version.py"
 
-[project.entry-points.multistage_build]
-# Declare automatic hooks for a multistage-build using project.
-post-build-wheel = "retrofy._pep517_hooks:compatibility_via_rewrite"
-post-build-editable = "retrofy._pep517_hooks:compatibility_via_import_hook"
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 88
+force_sort_within_sections = true

--- a/retrofy/_converters.py
+++ b/retrofy/_converters.py
@@ -3,7 +3,13 @@ import typing
 
 import libcst as cst
 
-from ._transformations import dataclass, match_statement, type_alias, walrus
+from ._transformations import (
+    dataclass,
+    match_statement,
+    type_alias,
+    typing_final,
+    walrus,
+)
 
 
 class TypingTransformer(cst.CSTTransformer):
@@ -163,12 +169,17 @@ def convert_dataclass(module: cst.Module) -> cst.Module:
     return module.visit(dataclass.DataclassTransformer())
 
 
+def convert_typing_final(module: cst.Module) -> cst.Module:
+    return module.visit(typing_final.TypingFinalTransformer())
+
+
 def convert(code: str) -> str:
     mod = cst.parse_module(code)
     mod = convert_sequence_subscript(mod)
     mod = convert_walrus_operator(mod)
     mod = convert_type_alias(mod)
     mod = convert_dataclass(mod)
+    mod = convert_typing_final(mod)
     mod = convert_match_statement(mod)
     mod = convert_union(mod)
     return mod.code

--- a/retrofy/_converters.py
+++ b/retrofy/_converters.py
@@ -1,5 +1,4 @@
 import dataclasses
-import typing
 
 import libcst as cst
 
@@ -10,13 +9,14 @@ from ._transformations import (
     typing_final,
     walrus,
 )
+from ._transformations.import_utils import EnhancedImportManager
 
 
 class TypingTransformer(cst.CSTTransformer):
     def __init__(self, scope):
         self._scope = scope
         self._require_typing = False
-        self._has_typing = False  # TODO: We can figure this out.
+        self.import_manager = EnhancedImportManager()
 
     def leave_Annotation(
         self,
@@ -48,76 +48,13 @@ class TypingTransformer(cst.CSTTransformer):
 
     def leave_Module(self, node: cst.Module, updated_node: cst.Module) -> cst.Module:
         if self._require_typing:
-            # Find the correct position to insert the typing import
-            # It should be after any docstrings and __future__ imports
-            insert_position = self._find_typing_import_position(updated_node.body)
+            # Scan existing imports and add typing import if needed
+            self.import_manager.scan_imports(updated_node.body)
+            new_body = list(updated_node.body)
+            new_body = self.import_manager.ensure_direct_import(new_body, "typing")
 
-            typing_import = cst.SimpleStatementLine(
-                [
-                    cst.Import(
-                        [
-                            cst.ImportAlias(
-                                cst.Name("typing"),
-                            ),
-                        ],
-                    ),
-                ],
-                trailing_whitespace=cst.TrailingWhitespace(
-                    newline=cst.Newline(),
-                ),
-            )
-
-            new_stmts = list(updated_node.body)
-            new_stmts.insert(insert_position, typing_import)
-
-            return dataclasses.replace(updated_node, body=tuple(new_stmts))
+            return dataclasses.replace(updated_node, body=tuple(new_body))
         return updated_node
-
-    def _find_typing_import_position(
-        self,
-        body: typing.Tuple[cst.BaseStatement, ...],
-    ) -> int:
-        """Find the correct position to insert the typing import."""
-        position = 0
-
-        # Skip module docstrings
-        if body and isinstance(body[0], cst.SimpleStatementLine):
-            if (
-                len(body[0].body) == 1
-                and isinstance(body[0].body[0], cst.Expr)
-                and isinstance(body[0].body[0].value, cst.SimpleString)
-            ):
-                position = 1
-
-        # Skip __future__ imports
-        for i in range(position, len(body)):
-            stmt = body[i]
-            if isinstance(stmt, cst.SimpleStatementLine):
-                for substmt in stmt.body:
-                    if (
-                        isinstance(substmt, cst.ImportFrom)
-                        and substmt.module
-                        and isinstance(substmt.module, cst.Attribute)
-                        and substmt.module.attr.value == "__future__"
-                    ):
-                        position = i + 1
-                        break
-                    elif (
-                        isinstance(substmt, cst.ImportFrom)
-                        and substmt.module
-                        and isinstance(substmt.module, cst.Name)
-                        and substmt.module.value == "__future__"
-                    ):
-                        position = i + 1
-                        break
-                else:
-                    # If we didn't find a __future__ import in this statement, stop looking
-                    break
-            else:
-                # If we hit a non-simple statement, stop looking
-                break
-
-        return position
 
 
 def convert_union(module: cst.Module) -> cst.Module:

--- a/retrofy/_meta_hook_converter.py
+++ b/retrofy/_meta_hook_converter.py
@@ -1,6 +1,6 @@
+from importlib.abc import MetaPathFinder, SourceLoader
 import sys
 import typing
-from importlib.abc import MetaPathFinder, SourceLoader
 
 from ._converters import convert
 

--- a/retrofy/_transformations/import_utils.py
+++ b/retrofy/_transformations/import_utils.py
@@ -1,6 +1,6 @@
 """Utilities for managing imports in transformations."""
 
-from typing import Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import libcst as cst
 
@@ -101,3 +101,309 @@ class ImportManager:
                 break
 
         return position
+
+
+class ImportInfo:
+    """Information about an import found in the module."""
+
+    def __init__(
+        self,
+        module_name: str,
+        imported_name: str,
+        alias: Optional[str] = None,
+        stmt_index: int = 0,
+        import_index: int = 0,
+    ):
+        self.module_name = module_name  # e.g., "typing"
+        self.imported_name = imported_name  # e.g., "final"
+        self.alias = alias  # e.g., "fi_na_l" if imported as "final as fi_na_l"
+        self.stmt_index = stmt_index  # Index in module body
+        self.import_index = import_index  # Index within the import statement
+
+    @property
+    def effective_name(self) -> str:
+        """The name used to reference this import in code."""
+        return self.alias if self.alias else self.imported_name
+
+
+class EnhancedImportManager:
+    """Enhanced import manager with sophisticated import manipulation capabilities."""
+
+    def __init__(self):
+        self._import_info: Dict[str, List[ImportInfo]] = {}
+        self._has_sys_import = False
+
+    def scan_imports(
+        self,
+        body: Union[Tuple[cst.BaseStatement, ...], List[cst.BaseStatement]],
+    ) -> None:
+        """Scan module body to detect existing imports and their aliases."""
+        self._import_info.clear()
+        self._has_sys_import = False
+
+        for stmt_idx, stmt in enumerate(body):
+            if isinstance(stmt, cst.SimpleStatementLine):
+                for substmt in stmt.body:
+                    if isinstance(substmt, cst.ImportFrom) and substmt.module:
+                        self._scan_import_from(substmt, stmt_idx)
+                    elif isinstance(substmt, cst.Import):
+                        self._scan_import(substmt, stmt_idx)
+
+    def _scan_import_from(self, import_stmt: cst.ImportFrom, stmt_idx: int) -> None:
+        """Scan a 'from X import Y' statement."""
+        if not isinstance(import_stmt.module, cst.Name):
+            return
+
+        module_name = import_stmt.module.value
+
+        if isinstance(import_stmt.names, (list, tuple)):
+            for import_idx, name in enumerate(import_stmt.names):
+                if isinstance(name, cst.ImportAlias) and isinstance(
+                    name.name,
+                    cst.Name,
+                ):
+                    imported_name = name.name.value
+                    alias = name.asname.name.value if name.asname else None
+
+                    info = ImportInfo(
+                        module_name=module_name,
+                        imported_name=imported_name,
+                        alias=alias,
+                        stmt_index=stmt_idx,
+                        import_index=import_idx,
+                    )
+
+                    if module_name not in self._import_info:
+                        self._import_info[module_name] = []
+                    self._import_info[module_name].append(info)
+
+    def _scan_import(self, import_stmt: cst.Import, stmt_idx: int) -> None:
+        """Scan a direct 'import X' statement."""
+        for alias in import_stmt.names:
+            if isinstance(alias.name, cst.Name) and alias.name.value == "sys":
+                self._has_sys_import = True
+                break
+
+    def has_import(self, module_name: str, imported_name: str) -> bool:
+        """Check if a specific import exists."""
+        if module_name not in self._import_info:
+            return False
+        return any(
+            info.imported_name == imported_name
+            for info in self._import_info[module_name]
+        )
+
+    def get_import_alias(self, module_name: str, imported_name: str) -> Optional[str]:
+        """Get the alias for an import, or None if not found or no alias."""
+        if module_name not in self._import_info:
+            return None
+        for info in self._import_info[module_name]:
+            if info.imported_name == imported_name:
+                return info.effective_name
+        return None
+
+    def remove_from_imports(
+        self,
+        body: List[cst.BaseStatement],
+        module_name: str,
+        imported_name: str,
+    ) -> List[cst.BaseStatement]:
+        """Remove a specific import from existing import statements."""
+        if module_name not in self._import_info:
+            return body
+
+        new_body = []
+        for stmt in body:
+            if isinstance(stmt, cst.SimpleStatementLine):
+                new_substmts = []
+                for substmt in stmt.body:
+                    if (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Name)
+                        and substmt.module.value == module_name
+                    ):
+                        # Filter out the specific import
+                        if isinstance(substmt.names, (list, tuple)):
+                            new_names = []
+                            for name in substmt.names:
+                                if (
+                                    isinstance(name, cst.ImportAlias)
+                                    and isinstance(name.name, cst.Name)
+                                    and name.name.value != imported_name
+                                ):
+                                    new_names.append(name)
+
+                            # Only keep the import if there are other names
+                            if new_names:
+                                new_substmt = substmt.with_changes(names=new_names)
+                                new_substmts.append(new_substmt)
+                        else:
+                            # Single name import - keep if not the target
+                            if not (
+                                isinstance(substmt.names, cst.ImportAlias)
+                                and isinstance(substmt.names.name, cst.Name)
+                                and substmt.names.name.value == imported_name
+                            ):
+                                new_substmts.append(substmt)
+                    else:
+                        new_substmts.append(substmt)
+
+                if new_substmts:
+                    new_body.append(stmt.with_changes(body=new_substmts))
+            else:
+                new_body.append(stmt)
+
+        return new_body
+
+    def ensure_sys_import(
+        self,
+        body: List[cst.BaseStatement],
+    ) -> List[cst.BaseStatement]:
+        """Ensure sys is imported early in the module."""
+        # Check if sys is already imported in import section
+        early_sys_import = self._check_early_sys_import(body)
+
+        if not early_sys_import:
+            # Add sys import at the appropriate position
+            insert_position = self.find_import_position(body)
+            sys_import = self._create_sys_import()
+            body.insert(insert_position, sys_import)
+
+        return body
+
+    def _check_early_sys_import(self, body: List[cst.BaseStatement]) -> bool:
+        """Check if sys is imported early in the module (before non-import statements)."""
+        for stmt in body:
+            if isinstance(stmt, cst.SimpleStatementLine):
+                # Check if this is an import statement
+                has_imports = any(
+                    isinstance(substmt, (cst.Import, cst.ImportFrom))
+                    for substmt in stmt.body
+                )
+
+                for substmt in stmt.body:
+                    if isinstance(substmt, cst.Import) and any(
+                        isinstance(alias.name, cst.Name) and alias.name.value == "sys"
+                        for alias in substmt.names
+                    ):
+                        return True
+
+                # If we hit non-import statements, stop looking
+                if not has_imports:
+                    break
+            else:
+                # If we hit a non-simple statement, stop looking
+                break
+
+        return False
+
+    def _create_sys_import(self) -> cst.SimpleStatementLine:
+        """Create a sys import statement."""
+        return cst.SimpleStatementLine(
+            [
+                cst.Import(
+                    [
+                        cst.ImportAlias(
+                            cst.Name("sys"),
+                        ),
+                    ],
+                ),
+            ],
+            trailing_whitespace=cst.TrailingWhitespace(
+                newline=cst.Newline(),
+            ),
+        )
+
+    def find_import_position(self, body: List[cst.BaseStatement]) -> int:
+        """Find the correct position to insert imports (after __future__ imports)."""
+        position = 0
+
+        # Skip module docstrings
+        if body and isinstance(body[0], cst.SimpleStatementLine):
+            if (
+                len(body[0].body) == 1
+                and isinstance(body[0].body[0], cst.Expr)
+                and isinstance(body[0].body[0].value, cst.SimpleString)
+            ):
+                position = 1
+
+        # Skip __future__ imports
+        for i in range(position, len(body)):
+            stmt = body[i]
+            if isinstance(stmt, cst.SimpleStatementLine):
+                for substmt in stmt.body:
+                    if (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Attribute)
+                        and substmt.module.attr.value == "__future__"
+                    ):
+                        position = i + 1
+                        break
+                    elif (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Name)
+                        and substmt.module.value == "__future__"
+                    ):
+                        position = i + 1
+                        break
+                else:
+                    break
+            else:
+                break
+
+        return position
+
+    def find_post_import_position(self, body: List[cst.BaseStatement]) -> int:
+        """Find the position after all imports (for adding conditional blocks)."""
+        position = 0
+
+        # Skip module docstrings
+        if body and isinstance(body[0], cst.SimpleStatementLine):
+            if (
+                len(body[0].body) == 1
+                and isinstance(body[0].body[0], cst.Expr)
+                and isinstance(body[0].body[0].value, cst.SimpleString)
+            ):
+                position = 1
+
+        # Skip all imports
+        for i in range(position, len(body)):
+            stmt = body[i]
+            if isinstance(stmt, cst.SimpleStatementLine):
+                # If this statement contains any imports, skip it
+                if any(
+                    isinstance(substmt, (cst.Import, cst.ImportFrom))
+                    for substmt in stmt.body
+                ):
+                    position = i + 1
+                else:
+                    break
+            else:
+                break
+
+        return position
+
+    def create_conditional_import(
+        self,
+        condition: cst.Comparison,
+        if_import: cst.ImportFrom,
+        else_assignment: cst.Assign,
+    ) -> cst.If:
+        """Create a conditional import block with version check."""
+        if_body = cst.IndentedBlock([cst.SimpleStatementLine([if_import])])
+        else_body = cst.IndentedBlock([cst.SimpleStatementLine([else_assignment])])
+
+        return cst.If(
+            test=condition,
+            body=if_body,
+            orelse=cst.Else(body=else_body),
+            leading_lines=[
+                cst.EmptyLine(
+                    whitespace=cst.SimpleWhitespace(""),
+                    comment=None,
+                ),
+            ],
+        )

--- a/retrofy/_transformations/typing_final.py
+++ b/retrofy/_transformations/typing_final.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import List
-
 import libcst as cst
+
+from .import_utils import EnhancedImportManager
 
 
 class TypingFinalTransformer(cst.CSTTransformer):
@@ -14,12 +14,10 @@ class TypingFinalTransformer(cst.CSTTransformer):
     """
 
     def __init__(self) -> None:
+        self.import_manager = EnhancedImportManager()
         self.has_final_usage = False
         self.final_import_style: str | None = None  # "from_typing" or "typing_dot"
-        self.has_sys_import = False
-        self.final_alias: str | None = (
-            None  # Store the alias name if final is imported as alias
-        )
+        self.final_alias: str | None = None
 
     def leave_Module(
         self,
@@ -27,30 +25,40 @@ class TypingFinalTransformer(cst.CSTTransformer):
         updated_node: cst.Module,
     ) -> cst.Module:
         """Transform the entire module to add version compatibility checks."""
-        # First, scan for final imports to detect aliases
-        self._scan_for_final_imports(updated_node.body)
+        # Scan for imports to detect final usage and aliases
+        self.import_manager.scan_imports(updated_node.body)
+        self._detect_final_usage()
 
         if not self.has_final_usage:
             return updated_node
 
-        # Check if sys is already imported
-        self._check_existing_sys_import(updated_node.body)
+        # Start with the updated body as a list
+        new_body = list(updated_node.body)
 
-        # Remove final from existing imports and update them
-        new_body = self._update_imports(list(updated_node.body))
+        # Remove final from existing imports if needed
+        if self.final_import_style == "from_typing":
+            new_body = self.import_manager.remove_from_imports(
+                new_body,
+                "typing",
+                "final",
+            )
 
-        # Add sys import if needed
-        if not self.has_sys_import:
-            sys_insert_position = self._find_sys_import_position(new_body)
-            sys_import = self._create_sys_import()
-            new_body.insert(sys_insert_position, sys_import)
+        # Ensure sys import is present
+        new_body = self.import_manager.ensure_sys_import(new_body)
 
-        # Find position to insert version check after imports
-        version_check_position = self._find_version_check_position(new_body)
+        # Add version check after imports
+        version_check_position = self.import_manager.find_post_import_position(new_body)
         version_check = self._create_version_check_block()
         new_body.insert(version_check_position, version_check)
 
         return updated_node.with_changes(body=new_body)
+
+    def _detect_final_usage(self) -> None:
+        """Detect if final is imported and determine usage style."""
+        if self.import_manager.has_import("typing", "final"):
+            self.has_final_usage = True
+            self.final_import_style = "from_typing"
+            self.final_alias = self.import_manager.get_import_alias("typing", "final")
 
     def leave_Decorator(
         self,
@@ -58,19 +66,6 @@ class TypingFinalTransformer(cst.CSTTransformer):
         updated_node: cst.Decorator,
     ) -> cst.Decorator:
         """Transform @final decorators to use the version-compatible alias."""
-
-        # Check for @final or @alias_name (where alias_name is an alias for final)
-        if isinstance(updated_node.decorator, cst.Name):
-            decorator_name = updated_node.decorator.value
-            # We need to determine if this decorator is referring to final
-            # We'll detect this during import processing and store the alias
-            if decorator_name == "final" or (
-                self.final_alias and decorator_name == self.final_alias
-            ):
-                self.has_final_usage = True
-                self.final_import_style = "from_typing"
-                # Keep using the same decorator name
-                return updated_node
 
         # Check for @typing.final
         if (
@@ -84,246 +79,6 @@ class TypingFinalTransformer(cst.CSTTransformer):
             return updated_node.with_changes(decorator=cst.Name("__typing_final"))
 
         return updated_node
-
-    def _scan_for_final_imports(self, body) -> None:
-        """Scan the module body to detect final imports and their aliases."""
-        for stmt in body:
-            if isinstance(stmt, cst.SimpleStatementLine):
-                for substmt in stmt.body:
-                    if (
-                        isinstance(substmt, cst.ImportFrom)
-                        and substmt.module
-                        and isinstance(substmt.module, cst.Name)
-                        and substmt.module.value == "typing"
-                    ):
-                        # Check if final is in the import list
-                        if isinstance(substmt.names, (list, tuple)):
-                            for name in substmt.names:
-                                if (
-                                    isinstance(name, cst.ImportAlias)
-                                    and isinstance(name.name, cst.Name)
-                                    and name.name.value == "final"
-                                ):
-                                    self.has_final_usage = True
-                                    self.final_import_style = "from_typing"
-                                    if name.asname:
-                                        # final imported with alias
-                                        self.final_alias = name.asname.name.value
-                                    else:
-                                        # final imported without alias
-                                        self.final_alias = "final"
-                                    return
-
-    def _check_existing_sys_import(self, body) -> None:
-        """Check if sys is already imported early in the module."""
-        for i, stmt in enumerate(body):
-            if isinstance(stmt, cst.SimpleStatementLine):
-                # Check if this is an import statement
-                has_imports = any(
-                    isinstance(substmt, (cst.Import, cst.ImportFrom))
-                    for substmt in stmt.body
-                )
-
-                for substmt in stmt.body:
-                    if isinstance(substmt, cst.Import) and any(
-                        isinstance(alias.name, cst.Name) and alias.name.value == "sys"
-                        for alias in substmt.names
-                    ):
-                        self.has_sys_import = True
-                        return
-
-                # If we hit non-import statements, stop looking for sys imports
-                # as we only want sys imports that come before the version check
-                if not has_imports:
-                    break
-            else:
-                # If we hit a non-simple statement, stop looking
-                break
-
-    def _update_imports(self, body: List[cst.BaseStatement]) -> List[cst.BaseStatement]:
-        """Remove final from existing typing imports."""
-        if self.final_import_style != "from_typing":
-            return body
-
-        new_body = []
-        for stmt in body:
-            if isinstance(stmt, cst.SimpleStatementLine):
-                new_substmts = []
-                for substmt in stmt.body:
-                    if (
-                        isinstance(substmt, cst.ImportFrom)
-                        and substmt.module
-                        and isinstance(substmt.module, cst.Name)
-                        and substmt.module.value == "typing"
-                    ):
-                        # Filter out final from the import
-                        if isinstance(substmt.names, (list, tuple)):
-                            new_names = []
-                            for name in substmt.names:
-                                if (
-                                    isinstance(name, cst.ImportAlias)
-                                    and isinstance(name.name, cst.Name)
-                                    and name.name.value != "final"
-                                ):
-                                    new_names.append(name)
-
-                            # Only keep the import if there are other names
-                            if new_names:
-                                new_substmt = substmt.with_changes(names=new_names)
-                                new_substmts.append(new_substmt)
-                        else:
-                            # Single name or star import - keep as is if not final
-                            if not (
-                                isinstance(substmt.names, cst.ImportAlias)
-                                and isinstance(substmt.names.name, cst.Name)
-                                and substmt.names.name.value == "final"
-                            ):
-                                new_substmts.append(substmt)
-                    else:
-                        new_substmts.append(substmt)
-
-                if new_substmts:
-                    new_body.append(stmt.with_changes(body=new_substmts))
-            else:
-                new_body.append(stmt)
-
-        return new_body
-
-    def _create_sys_import(self) -> cst.SimpleStatementLine:
-        """Create sys import statement."""
-        return cst.SimpleStatementLine(
-            [
-                cst.Import(
-                    [
-                        cst.ImportAlias(
-                            cst.Name("sys"),
-                        ),
-                    ],
-                ),
-            ],
-            trailing_whitespace=cst.TrailingWhitespace(
-                newline=cst.Newline(),
-            ),
-        )
-
-    def _find_sys_import_position(self, body: List[cst.BaseStatement]) -> int:
-        """Find the correct position to insert sys import."""
-        position = 0
-
-        # Skip module docstrings
-        if body and isinstance(body[0], cst.SimpleStatementLine):
-            if (
-                len(body[0].body) == 1
-                and isinstance(body[0].body[0], cst.Expr)
-                and isinstance(body[0].body[0].value, cst.SimpleString)
-            ):
-                position = 1
-
-        # Skip __future__ imports
-        for i in range(position, len(body)):
-            stmt = body[i]
-            if isinstance(stmt, cst.SimpleStatementLine):
-                for substmt in stmt.body:
-                    if (
-                        isinstance(substmt, cst.ImportFrom)
-                        and substmt.module
-                        and isinstance(substmt.module, cst.Attribute)
-                        and substmt.module.attr.value == "__future__"
-                    ):
-                        position = i + 1
-                        break
-                    elif (
-                        isinstance(substmt, cst.ImportFrom)
-                        and substmt.module
-                        and isinstance(substmt.module, cst.Name)
-                        and substmt.module.value == "__future__"
-                    ):
-                        position = i + 1
-                        break
-                else:
-                    break
-            else:
-                break
-
-        return position
-
-    def _find_version_check_position(self, body: List[cst.BaseStatement]) -> int:
-        """Find the correct position to insert version check after all imports."""
-        position = 0
-
-        # Skip module docstrings
-        if body and isinstance(body[0], cst.SimpleStatementLine):
-            if (
-                len(body[0].body) == 1
-                and isinstance(body[0].body[0], cst.Expr)
-                and isinstance(body[0].body[0].value, cst.SimpleString)
-            ):
-                position = 1
-
-        # Skip all imports
-        for i in range(position, len(body)):
-            stmt = body[i]
-            if isinstance(stmt, cst.SimpleStatementLine):
-                # If this statement contains any imports, skip it
-                if any(
-                    isinstance(substmt, (cst.Import, cst.ImportFrom))
-                    for substmt in stmt.body
-                ):
-                    position = i + 1
-                else:
-                    break
-            else:
-                break
-
-        return position
-
-    def _find_import_insertion_position(self, body: List[cst.BaseStatement]) -> int:
-        """Find the correct position to insert imports."""
-        position = 0
-
-        # Skip module docstrings
-        if body and isinstance(body[0], cst.SimpleStatementLine):
-            if (
-                len(body[0].body) == 1
-                and isinstance(body[0].body[0], cst.Expr)
-                and isinstance(body[0].body[0].value, cst.SimpleString)
-            ):
-                position = 1
-
-        # Skip __future__ imports
-        for i in range(position, len(body)):
-            stmt = body[i]
-            if isinstance(stmt, cst.SimpleStatementLine):
-                for substmt in stmt.body:
-                    if (
-                        isinstance(substmt, cst.ImportFrom)
-                        and substmt.module
-                        and isinstance(substmt.module, cst.Attribute)
-                        and substmt.module.attr.value == "__future__"
-                    ):
-                        position = i + 1
-                        break
-                    elif (
-                        isinstance(substmt, cst.ImportFrom)
-                        and substmt.module
-                        and isinstance(substmt.module, cst.Name)
-                        and substmt.module.value == "__future__"
-                    ):
-                        position = i + 1
-                        break
-                else:
-                    # Skip all imports
-                    if any(
-                        isinstance(substmt, (cst.Import, cst.ImportFrom))
-                        for substmt in stmt.body
-                    ):
-                        position = i + 1
-                    else:
-                        break
-            else:
-                break
-
-        return position
 
     def _create_version_check_block(self) -> cst.If:
         """Create the version check block for typing.final compatibility."""

--- a/retrofy/_transformations/typing_final.py
+++ b/retrofy/_transformations/typing_final.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+from typing import List
+
+import libcst as cst
+
+
+class TypingFinalTransformer(cst.CSTTransformer):
+    """
+    Transform @final decorators to use sys.version_info checks for compatibility.
+
+    This transformation wraps typing.final usage in version checks for Python < 3.8
+    compatibility, using lambda cls: cls as fallback.
+    """
+
+    def __init__(self) -> None:
+        self.has_final_usage = False
+        self.final_import_style: str | None = None  # "from_typing" or "typing_dot"
+        self.has_sys_import = False
+        self.final_alias: str | None = (
+            None  # Store the alias name if final is imported as alias
+        )
+
+    def leave_Module(
+        self,
+        original_node: cst.Module,
+        updated_node: cst.Module,
+    ) -> cst.Module:
+        """Transform the entire module to add version compatibility checks."""
+        # First, scan for final imports to detect aliases
+        self._scan_for_final_imports(updated_node.body)
+
+        if not self.has_final_usage:
+            return updated_node
+
+        # Check if sys is already imported
+        self._check_existing_sys_import(updated_node.body)
+
+        # Remove final from existing imports and update them
+        new_body = self._update_imports(list(updated_node.body))
+
+        # Add sys import if needed
+        if not self.has_sys_import:
+            sys_insert_position = self._find_sys_import_position(new_body)
+            sys_import = self._create_sys_import()
+            new_body.insert(sys_insert_position, sys_import)
+
+        # Find position to insert version check after imports
+        version_check_position = self._find_version_check_position(new_body)
+        version_check = self._create_version_check_block()
+        new_body.insert(version_check_position, version_check)
+
+        return updated_node.with_changes(body=new_body)
+
+    def leave_Decorator(
+        self,
+        original_node: cst.Decorator,
+        updated_node: cst.Decorator,
+    ) -> cst.Decorator:
+        """Transform @final decorators to use the version-compatible alias."""
+
+        # Check for @final or @alias_name (where alias_name is an alias for final)
+        if isinstance(updated_node.decorator, cst.Name):
+            decorator_name = updated_node.decorator.value
+            # We need to determine if this decorator is referring to final
+            # We'll detect this during import processing and store the alias
+            if decorator_name == "final" or (
+                self.final_alias and decorator_name == self.final_alias
+            ):
+                self.has_final_usage = True
+                self.final_import_style = "from_typing"
+                # Keep using the same decorator name
+                return updated_node
+
+        # Check for @typing.final
+        if (
+            isinstance(updated_node.decorator, cst.Attribute)
+            and isinstance(updated_node.decorator.value, cst.Name)
+            and updated_node.decorator.value.value == "typing"
+            and updated_node.decorator.attr.value == "final"
+        ):
+            self.has_final_usage = True
+            self.final_import_style = "typing_dot"
+            return updated_node.with_changes(decorator=cst.Name("__typing_final"))
+
+        return updated_node
+
+    def _scan_for_final_imports(self, body) -> None:
+        """Scan the module body to detect final imports and their aliases."""
+        for stmt in body:
+            if isinstance(stmt, cst.SimpleStatementLine):
+                for substmt in stmt.body:
+                    if (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Name)
+                        and substmt.module.value == "typing"
+                    ):
+                        # Check if final is in the import list
+                        if isinstance(substmt.names, (list, tuple)):
+                            for name in substmt.names:
+                                if (
+                                    isinstance(name, cst.ImportAlias)
+                                    and isinstance(name.name, cst.Name)
+                                    and name.name.value == "final"
+                                ):
+                                    self.has_final_usage = True
+                                    self.final_import_style = "from_typing"
+                                    if name.asname:
+                                        # final imported with alias
+                                        self.final_alias = name.asname.name.value
+                                    else:
+                                        # final imported without alias
+                                        self.final_alias = "final"
+                                    return
+
+    def _check_existing_sys_import(self, body) -> None:
+        """Check if sys is already imported early in the module."""
+        for i, stmt in enumerate(body):
+            if isinstance(stmt, cst.SimpleStatementLine):
+                # Check if this is an import statement
+                has_imports = any(
+                    isinstance(substmt, (cst.Import, cst.ImportFrom))
+                    for substmt in stmt.body
+                )
+
+                for substmt in stmt.body:
+                    if isinstance(substmt, cst.Import) and any(
+                        isinstance(alias.name, cst.Name) and alias.name.value == "sys"
+                        for alias in substmt.names
+                    ):
+                        self.has_sys_import = True
+                        return
+
+                # If we hit non-import statements, stop looking for sys imports
+                # as we only want sys imports that come before the version check
+                if not has_imports:
+                    break
+            else:
+                # If we hit a non-simple statement, stop looking
+                break
+
+    def _update_imports(self, body: List[cst.BaseStatement]) -> List[cst.BaseStatement]:
+        """Remove final from existing typing imports."""
+        if self.final_import_style != "from_typing":
+            return body
+
+        new_body = []
+        for stmt in body:
+            if isinstance(stmt, cst.SimpleStatementLine):
+                new_substmts = []
+                for substmt in stmt.body:
+                    if (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Name)
+                        and substmt.module.value == "typing"
+                    ):
+                        # Filter out final from the import
+                        if isinstance(substmt.names, (list, tuple)):
+                            new_names = []
+                            for name in substmt.names:
+                                if (
+                                    isinstance(name, cst.ImportAlias)
+                                    and isinstance(name.name, cst.Name)
+                                    and name.name.value != "final"
+                                ):
+                                    new_names.append(name)
+
+                            # Only keep the import if there are other names
+                            if new_names:
+                                new_substmt = substmt.with_changes(names=new_names)
+                                new_substmts.append(new_substmt)
+                        else:
+                            # Single name or star import - keep as is if not final
+                            if not (
+                                isinstance(substmt.names, cst.ImportAlias)
+                                and isinstance(substmt.names.name, cst.Name)
+                                and substmt.names.name.value == "final"
+                            ):
+                                new_substmts.append(substmt)
+                    else:
+                        new_substmts.append(substmt)
+
+                if new_substmts:
+                    new_body.append(stmt.with_changes(body=new_substmts))
+            else:
+                new_body.append(stmt)
+
+        return new_body
+
+    def _create_sys_import(self) -> cst.SimpleStatementLine:
+        """Create sys import statement."""
+        return cst.SimpleStatementLine(
+            [
+                cst.Import(
+                    [
+                        cst.ImportAlias(
+                            cst.Name("sys"),
+                        ),
+                    ],
+                ),
+            ],
+            trailing_whitespace=cst.TrailingWhitespace(
+                newline=cst.Newline(),
+            ),
+        )
+
+    def _find_sys_import_position(self, body: List[cst.BaseStatement]) -> int:
+        """Find the correct position to insert sys import."""
+        position = 0
+
+        # Skip module docstrings
+        if body and isinstance(body[0], cst.SimpleStatementLine):
+            if (
+                len(body[0].body) == 1
+                and isinstance(body[0].body[0], cst.Expr)
+                and isinstance(body[0].body[0].value, cst.SimpleString)
+            ):
+                position = 1
+
+        # Skip __future__ imports
+        for i in range(position, len(body)):
+            stmt = body[i]
+            if isinstance(stmt, cst.SimpleStatementLine):
+                for substmt in stmt.body:
+                    if (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Attribute)
+                        and substmt.module.attr.value == "__future__"
+                    ):
+                        position = i + 1
+                        break
+                    elif (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Name)
+                        and substmt.module.value == "__future__"
+                    ):
+                        position = i + 1
+                        break
+                else:
+                    break
+            else:
+                break
+
+        return position
+
+    def _find_version_check_position(self, body: List[cst.BaseStatement]) -> int:
+        """Find the correct position to insert version check after all imports."""
+        position = 0
+
+        # Skip module docstrings
+        if body and isinstance(body[0], cst.SimpleStatementLine):
+            if (
+                len(body[0].body) == 1
+                and isinstance(body[0].body[0], cst.Expr)
+                and isinstance(body[0].body[0].value, cst.SimpleString)
+            ):
+                position = 1
+
+        # Skip all imports
+        for i in range(position, len(body)):
+            stmt = body[i]
+            if isinstance(stmt, cst.SimpleStatementLine):
+                # If this statement contains any imports, skip it
+                if any(
+                    isinstance(substmt, (cst.Import, cst.ImportFrom))
+                    for substmt in stmt.body
+                ):
+                    position = i + 1
+                else:
+                    break
+            else:
+                break
+
+        return position
+
+    def _find_import_insertion_position(self, body: List[cst.BaseStatement]) -> int:
+        """Find the correct position to insert imports."""
+        position = 0
+
+        # Skip module docstrings
+        if body and isinstance(body[0], cst.SimpleStatementLine):
+            if (
+                len(body[0].body) == 1
+                and isinstance(body[0].body[0], cst.Expr)
+                and isinstance(body[0].body[0].value, cst.SimpleString)
+            ):
+                position = 1
+
+        # Skip __future__ imports
+        for i in range(position, len(body)):
+            stmt = body[i]
+            if isinstance(stmt, cst.SimpleStatementLine):
+                for substmt in stmt.body:
+                    if (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Attribute)
+                        and substmt.module.attr.value == "__future__"
+                    ):
+                        position = i + 1
+                        break
+                    elif (
+                        isinstance(substmt, cst.ImportFrom)
+                        and substmt.module
+                        and isinstance(substmt.module, cst.Name)
+                        and substmt.module.value == "__future__"
+                    ):
+                        position = i + 1
+                        break
+                else:
+                    # Skip all imports
+                    if any(
+                        isinstance(substmt, (cst.Import, cst.ImportFrom))
+                        for substmt in stmt.body
+                    ):
+                        position = i + 1
+                    else:
+                        break
+            else:
+                break
+
+        return position
+
+    def _create_version_check_block(self) -> cst.If:
+        """Create the version check block for typing.final compatibility."""
+
+        # Create the condition: sys.version_info >= (3, 8)
+        condition = cst.Comparison(
+            left=cst.Attribute(
+                value=cst.Name("sys"),
+                attr=cst.Name("version_info"),
+            ),
+            comparisons=[
+                cst.ComparisonTarget(
+                    operator=cst.GreaterThanEqual(),
+                    comparator=cst.Tuple(
+                        [
+                            cst.Element(cst.Integer("3")),
+                            cst.Element(cst.Integer("8")),
+                        ],
+                    ),
+                ),
+            ],
+        )
+
+        # Create the if body based on import style
+        if self.final_import_style == "from_typing":
+            # Determine the import and assignment name
+            alias_name = self.final_alias or "final"
+
+            # from typing import final [as alias_name]
+            if alias_name == "final":
+                import_alias = cst.ImportAlias(name=cst.Name("final"))
+            else:
+                import_alias = cst.ImportAlias(
+                    name=cst.Name("final"),
+                    asname=cst.AsName(name=cst.Name(alias_name)),
+                )
+
+            if_body = cst.IndentedBlock(
+                [
+                    cst.SimpleStatementLine(
+                        [
+                            cst.ImportFrom(
+                                module=cst.Name("typing"),
+                                names=[import_alias],
+                            ),
+                        ],
+                    ),
+                ],
+            )
+
+            # alias_name = lambda cls: cls
+            else_body = cst.IndentedBlock(
+                [
+                    cst.SimpleStatementLine(
+                        [
+                            cst.Assign(
+                                targets=[cst.AssignTarget(cst.Name(alias_name))],
+                                value=cst.Lambda(
+                                    params=cst.Parameters(
+                                        [
+                                            cst.Param(cst.Name("cls")),
+                                        ],
+                                    ),
+                                    body=cst.Name("cls"),
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+            )
+        else:  # typing_dot
+            # from typing import final as __typing_final
+            if_body = cst.IndentedBlock(
+                [
+                    cst.SimpleStatementLine(
+                        [
+                            cst.ImportFrom(
+                                module=cst.Name("typing"),
+                                names=[
+                                    cst.ImportAlias(
+                                        name=cst.Name("final"),
+                                        asname=cst.AsName(
+                                            name=cst.Name("__typing_final"),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            )
+
+            # __typing_final = lambda cls: cls
+            else_body = cst.IndentedBlock(
+                [
+                    cst.SimpleStatementLine(
+                        [
+                            cst.Assign(
+                                targets=[cst.AssignTarget(cst.Name("__typing_final"))],
+                                value=cst.Lambda(
+                                    params=cst.Parameters(
+                                        [
+                                            cst.Param(cst.Name("cls")),
+                                        ],
+                                    ),
+                                    body=cst.Name("cls"),
+                                ),
+                            ),
+                        ],
+                    ),
+                ],
+            )
+
+        # Create the complete if statement
+        return cst.If(
+            test=condition,
+            body=if_body,
+            orelse=cst.Else(body=else_body),
+            leading_lines=[
+                cst.EmptyLine(
+                    whitespace=cst.SimpleWhitespace(""),
+                    comment=None,
+                ),
+            ],
+        )

--- a/retrofy/tests/_transformations/test_match_statement.py
+++ b/retrofy/tests/_transformations/test_match_statement.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 import re
 import sys
 import textwrap
 import typing
-from dataclasses import dataclass
 
 import libcst
 import libcst as cst

--- a/retrofy/tests/_transformations/test_typing_final.py
+++ b/retrofy/tests/_transformations/test_typing_final.py
@@ -1,0 +1,413 @@
+import sys
+import textwrap
+from typing import Any, Dict
+
+import libcst as cst
+
+from retrofy._transformations.typing_final import TypingFinalTransformer
+
+
+def execute_code_with_results(code: str) -> Dict[str, Any]:
+    """Execute code and return the final locals() containing results."""
+    namespace = {"__builtins__": __builtins__}
+    exec(code, namespace)
+
+    # Filter out built-ins, functions, imports, and other non-result items
+    result_locals = {
+        k: v
+        for k, v in namespace.items()
+        if (not k.startswith("__") and not callable(v) and not hasattr(v, "__name__"))
+    }
+    return result_locals
+
+
+def transform_typing_final(source_code: str) -> str:
+    """Apply typing.final transformation to source code."""
+    module = cst.parse_module(source_code)
+    transformer = TypingFinalTransformer()
+    transformed_module = module.visit(transformer)
+    return transformed_module.code
+
+
+def test_typing_final_simple():
+    """Test simple typing.final transformation."""
+
+    source = textwrap.dedent("""
+    from typing import final
+
+    @final
+    class MyClass:
+        pass
+    """)
+
+    expected = textwrap.dedent("""
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import final
+    else:
+        final = lambda cls: cls
+
+    @final
+    class MyClass:
+        pass
+    """)
+
+    # Test calls to verify the decorator behavior
+    test_calls = textwrap.dedent("""
+    instance = MyClass()
+    has_final_attr = hasattr(MyClass, '__final__')
+    """)
+
+    # EXECUTION VALIDATION: Test converted code behavior (all Python versions)
+    converted_source_with_calls = expected + test_calls
+    converted_results = execute_code_with_results(converted_source_with_calls)
+
+    # Verify the class was created successfully
+    assert "instance" in converted_results
+
+    # STRING VALIDATION: Test exact code generation
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_from_typing():
+    """Test typing.final imported directly from typing module."""
+
+    source = textwrap.dedent("""
+    import typing
+
+    @typing.final
+    class MyClass:
+        pass
+    """)
+
+    expected = textwrap.dedent("""
+    import sys
+    import typing
+
+    if sys.version_info >= (3, 8):
+        from typing import final as __typing_final
+    else:
+        __typing_final = lambda cls: cls
+
+    @__typing_final
+    class MyClass:
+        pass
+    """)
+
+    # STRING VALIDATION: Test exact code generation
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_multiple_classes():
+    """Test typing.final with multiple classes."""
+
+    source = textwrap.dedent("""
+    from typing import final
+
+    @final
+    class ClassA:
+        pass
+
+    class ClassB:
+        pass
+
+    @final
+    class ClassC:
+        pass
+    """)
+
+    expected = textwrap.dedent("""
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import final
+    else:
+        final = lambda cls: cls
+
+    @final
+    class ClassA:
+        pass
+
+    class ClassB:
+        pass
+
+    @final
+    class ClassC:
+        pass
+    """)
+
+    # STRING VALIDATION: Test exact code generation
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_with_existing_sys_import():
+    """Test that existing sys import is preserved."""
+
+    source = textwrap.dedent("""
+    import sys
+    from typing import final, Union
+
+    @final
+    class MyClass:
+        a: typing.Union[str, int]
+    """)
+
+    expected = textwrap.dedent("""
+    import sys
+    from typing import Union
+
+    if sys.version_info >= (3, 8):
+        from typing import final
+    else:
+        final = lambda cls: cls
+
+    @final
+    class MyClass:
+        a: typing.Union[str, int]
+    """)
+
+    # STRING VALIDATION: Test exact code generation
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_with_future_import():
+    """Test that sys import is placed after __future__ imports."""
+
+    source = textwrap.dedent("""
+    from __future__ import annotations
+    from typing import final
+
+    @final
+    class MyClass:
+        pass
+    """)
+
+    expected = textwrap.dedent("""
+    from __future__ import annotations
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import final
+    else:
+        final = lambda cls: cls
+
+    @final
+    class MyClass:
+        pass
+    """)
+
+    # STRING VALIDATION: Test exact code generation
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_manual_alias():
+    source = textwrap.dedent("""
+    from typing import final
+
+    foo = final
+
+    @foo
+    class MyClass:
+        pass
+    """)
+
+    expected = textwrap.dedent("""
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import final
+    else:
+        final = lambda cls: cls
+
+    foo = final
+
+    @foo
+    class MyClass:
+        pass
+    """)
+
+    # STRING VALIDATION: Test exact code generation
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_no_transformation_needed():
+    """Test that code without typing.final is not transformed."""
+
+    source = textwrap.dedent("""
+    class MyClass:
+        pass
+
+    def my_function():
+        pass
+    """)
+
+    expected = textwrap.dedent("""
+    class MyClass:
+        pass
+
+    def my_function():
+        pass
+    """)
+
+    # STRING VALIDATION: Test exact code generation (no changes expected)
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_alias():
+    """Test that code without typing.final is not transformed."""
+
+    source = textwrap.dedent("""
+    from typing import final as fi_na_l, Union as foo, Optional
+
+    @fi_na_l
+    class MyClass:
+        pass
+    """)
+
+    expected = textwrap.dedent("""
+    import sys
+    from typing import Union as foo, Optional
+
+    if sys.version_info >= (3, 8):
+        from typing import final as fi_na_l
+    else:
+        fi_na_l = lambda cls: cls
+
+    @fi_na_l
+    class MyClass:
+        pass
+    """)
+
+    # STRING VALIDATION: Test exact code generation (no changes expected)
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_with_existing_imports_and_sys():
+    """Test typing.final transformation with existing imports including sys."""
+
+    source = textwrap.dedent("""
+    from typing import final
+
+    @final
+    class MyClass:
+        pass
+
+    import sys
+
+    print(sys.path)
+    """)
+
+    expected = textwrap.dedent("""
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import final
+    else:
+        final = lambda cls: cls
+
+    @final
+    class MyClass:
+        pass
+
+    import sys
+
+    print(sys.path)
+    """)
+
+    # STRING VALIDATION: Test exact code generation
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+def test_typing_final_mixed_decorators():
+    """Test typing.final with other decorators."""
+
+    source = textwrap.dedent("""
+    from typing import final
+
+    @final
+    @property
+    def my_method(self):
+        pass
+
+    @final
+    class MyClass:
+        @final
+        def my_method(self):
+            pass
+    """)
+
+    expected = textwrap.dedent("""
+    import sys
+
+    if sys.version_info >= (3, 8):
+        from typing import final
+    else:
+        final = lambda cls: cls
+
+    @final
+    @property
+    def my_method(self):
+        pass
+
+    @final
+    class MyClass:
+        @final
+        def my_method(self):
+            pass
+    """)
+
+    # STRING VALIDATION: Test exact code generation
+    result = transform_typing_final(source)
+    assert result == expected
+
+
+if sys.version_info >= (3, 8):
+
+    def test_typing_final_equivalence():
+        """Test that transformed code behaves equivalently to original in Python 3.8+."""
+
+        source = textwrap.dedent("""
+        from typing import final
+
+        @final
+        class MyClass:
+            pass
+        """)
+
+        expected = textwrap.dedent("""
+        import sys
+        if sys.version_info >= (3, 8):
+            from typing import final
+        else:
+            final = lambda cls: cls
+
+        @final
+        class MyClass:
+            pass
+        """)
+
+        # Test calls to verify the decorator behavior
+        test_calls = textwrap.dedent("""
+        instance = MyClass()
+        class_name = MyClass.__name__
+        """)
+
+        # EQUIVALENCE VALIDATION: Compare with original
+        original_source_with_calls = source + test_calls
+        original_results = execute_code_with_results(original_source_with_calls)
+
+        converted_source_with_calls = expected + test_calls
+        converted_results = execute_code_with_results(converted_source_with_calls)
+
+        # Both should create the same class
+        assert original_results["class_name"] == converted_results["class_name"]

--- a/retrofy/tests/test__converters.py
+++ b/retrofy/tests/test__converters.py
@@ -100,7 +100,6 @@ def test_union__future__with_import_already():
     expected = textwrap.dedent("""
     from __future__ import annotations
     import typing
-    import typing
 
     if typing.TYPE_CHECKING:
         c: typing.Union[str, int]


### PR DESCRIPTION
In the future, I envisage this will actually just call `typing-extensions`, but I will need to deal with dependency management in that case.