### PR TITLE
CI: run example-project tests end-to-end

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -83,6 +83,21 @@ jobs:
         cd not-the-source
         python -m pytest --pyargs retrofy -ssvv
 
+    - name: Build example-project (exercises the retrofy build rewrite)
+      run: |
+        python -m pip install build multistage-build
+        cd example-project
+        python -m build --no-isolation --wheel
+
+    - name: Install built example-project wheel
+      run: |
+        python -m pip install example-project/dist/*.whl
+
+    - name: Test example-project from isolation
+      run: |
+        cd not-the-source
+        python -m pytest --pyargs example_project -ssvv
+
   compatibility_test:
     strategy:
       matrix:

--- a/example-project/example_project/tests/test_walrus_comprehensions.py
+++ b/example-project/example_project/tests/test_walrus_comprehensions.py
@@ -2,8 +2,6 @@
 Test walrus operator in comprehensions.
 """
 
-import pytest
-
 
 def test_walrus_list_comprehension():
     """Test walrus operator in list comprehensions."""
@@ -14,7 +12,6 @@ def test_walrus_list_comprehension():
     assert result == ["hello", "world"]
 
 
-@pytest.mark.xfail(reason="retrofy bug", strict=True)
 def test_walrus_dict_comprehension():
     """Test walrus operator in dict comprehensions."""
     data = ["Hello", "World", "Hi"]

--- a/example-project/example_project/tests/test_walrus_short_circuit.py
+++ b/example-project/example_project/tests/test_walrus_short_circuit.py
@@ -5,7 +5,6 @@ Test walrus operator short-circuiting behavior.
 import pytest
 
 
-@pytest.mark.xfail(reason="retrofy bug", strict=True)
 def test_short_circuit_and():
     """Test that short-circuiting prevents unnecessary function calls."""
     call_count = 0


### PR DESCRIPTION
The existing ``test`` job only ran ``pytest --pyargs retrofy``, so the example-project tests never executed in CI. As a result, strict ``xfail`` markers in those tests that have started passing (because retrofy's transformations have caught up) flip to ``xpass`` silently. The failure was only visible if you ran the tests locally.
