### PR TITLE
Declare retrofy as editable-install runtime dep

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -245,30 +245,24 @@ jobs:
     - name: Run example-project tests via `uv run` (no-venv workflow)
       run: |
         # `uv run` is the modern uv UX: no explicit venv, uv manages
-        # the project environment automatically (creating an
-        # ``.venv``, installing the project as editable, and running
-        # the command). This exercises the same hook path as the
-        # `uv pip install --editable` step above but via the workflow
-        # most users will hit.
+        # the project environment automatically. We run in
+        # ``--no-project`` + ``--with-editable .`` mode rather than
+        # full project mode because the latter would try to produce a
+        # universal ``uv.lock`` across example-project's whole
+        # ``requires-python`` range (>=3.7), which is unsatisfiable —
+        # retrofy itself requires >=3.9, so editable installs simply
+        # cannot resolve for Python 3.7 / 3.8 (non-editable wheel
+        # installs of example-project still work on 3.7+). The
+        # ``--no-project`` path resolves only for the active
+        # interpreter and writes no lockfile.
         export PATH="$HOME/.local/bin:$PATH"
         cd example-project
-        # uv run reuses any existing ``.venv`` next to pyproject.toml,
-        # which would mask regressions if an earlier step (or a stale
-        # workspace) left one behind. Force a clean slate.
-        rm -rf .venv uv.lock
         UV_FIND_LINKS="${{ github.workspace }}/dist" \
         UV_BUILD_CONSTRAINT=/tmp/retrofy-build-constraint.txt \
         UV_CONSTRAINT=/tmp/retrofy-build-constraint.txt \
-          uv run --python ${{ matrix.python-version }} --with pytest \
+          uv run --no-project --python ${{ matrix.python-version }} \
+            --with-editable . --with pytest \
             python -m pytest example_project -ssvv
-
-        # Sanity-check uv pulled retrofy into its managed env.
-        if ! VIRTUAL_ENV=.venv uv pip list --format=freeze \
-            | grep -qE '^retrofy=='; then
-          echo "::error::uv run did not install retrofy into the managed env"
-          VIRTUAL_ENV=.venv uv pip list --format=freeze
-          exit 1
-        fi
 
   compatibility_test:
     strategy:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -242,6 +242,34 @@ jobs:
         cd not-the-source
         /tmp/editable-uv-venv/bin/pytest --pyargs example_project -ssvv
 
+    - name: Run example-project tests via `uv run` (no-venv workflow)
+      run: |
+        # `uv run` is the modern uv UX: no explicit venv, uv manages
+        # the project environment automatically (creating an
+        # ``.venv``, installing the project as editable, and running
+        # the command). This exercises the same hook path as the
+        # `uv pip install --editable` step above but via the workflow
+        # most users will hit.
+        export PATH="$HOME/.local/bin:$PATH"
+        cd example-project
+        # uv run reuses any existing ``.venv`` next to pyproject.toml,
+        # which would mask regressions if an earlier step (or a stale
+        # workspace) left one behind. Force a clean slate.
+        rm -rf .venv uv.lock
+        UV_FIND_LINKS="${{ github.workspace }}/dist" \
+        UV_BUILD_CONSTRAINT=/tmp/retrofy-build-constraint.txt \
+        UV_CONSTRAINT=/tmp/retrofy-build-constraint.txt \
+          uv run --python ${{ matrix.python-version }} --with pytest \
+            python -m pytest example_project -ssvv
+
+        # Sanity-check uv pulled retrofy into its managed env.
+        if ! VIRTUAL_ENV=.venv uv pip list --format=freeze \
+            | grep -qE '^retrofy=='; then
+          echo "::error::uv run did not install retrofy into the managed env"
+          VIRTUAL_ENV=.venv uv pip list --format=freeze
+          exit 1
+        fi
+
   compatibility_test:
     strategy:
       matrix:

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -166,41 +166,81 @@ jobs:
         # source through retrofy's meta-path loader at import time, so
         # retrofy itself must be importable at runtime.
         #
-        # TODO: drop the explicit ``pip install retrofy`` once
-        # retrofy's editable install path declares retrofy as a
-        # runtime requirement. Needs an upstream multistage-build
-        # ``post-prepare-metadata-for-build-editable`` hook used by
-        # retrofy.
-
+        # retrofy declares ``Requires-Dist: retrofy`` from
+        # ``prepare_metadata_for_build_editable`` (via the
+        # multistage-build hook of the same name), so pip resolves it
+        # and pulls it into the runtime env automatically. We then
+        # constrain pip to install the dev retrofy wheel (built earlier
+        # in this workflow) rather than the released version from
+        # PyPI, by adding it to ``--find-links`` and pinning it via a
+        # runtime constraint.
         python -m venv /tmp/editable-venv
         /tmp/editable-venv/bin/pip install --upgrade 'pip>=25.3'
         /tmp/editable-venv/bin/pip install pytest
 
+        # Use the same dev retrofy at both build- and run-time.
         export PIP_FIND_LINKS="${{ github.workspace }}/dist"
         export PIP_BUILD_CONSTRAINT=/tmp/retrofy-build-constraint.txt
-        /tmp/editable-venv/bin/pip install --editable example-project/
+        /tmp/editable-venv/bin/pip install \
+          --editable example-project/ \
+          --constraint /tmp/retrofy-build-constraint.txt
 
-        # Sanity-check the runtime-dep gap is still as documented in
-        # the TODO: today the editable install does NOT pull retrofy
-        # into the runtime env. When the multistage-build upstream fix
-        # lands and retrofy declares ``Requires-Dist: retrofy`` from
-        # ``prepare_metadata_for_build_editable``, this assertion will
-        # fail — at which point the TODO above can be closed and the
-        # manual ``pip install retrofy`` below removed.
-        if /tmp/editable-venv/bin/pip list --format=freeze | grep -qE '^retrofy=='; then
-          echo "::error::retrofy was pulled in by the editable install — TODO above can now be addressed: remove the assertion and the manual install below"
+        # The editable install path MUST pull retrofy as a runtime dep
+        # (retrofy's import-time rewriter runs against the user's
+        # source on each import, so retrofy must be importable). If
+        # this assertion ever flips, the multistage-build hook chain
+        # has regressed.
+        if ! /tmp/editable-venv/bin/pip list --format=freeze | grep -qE '^retrofy=='; then
+          echo "::error::editable install did not pull retrofy as a runtime dep — multistage-build post-prepare-metadata-for-build-editable hook likely regressed"
+          /tmp/editable-venv/bin/pip list --format=freeze
           exit 1
         fi
-        echo "Confirmed editable install does NOT pull retrofy; applying manual workaround"
-
-        # Install dev retrofy directly from the wheel — ``pip install
-        # retrofy`` would resolve a released version from PyPI.
-        /tmp/editable-venv/bin/pip install dist/retrofy-*-py3-none-any.whl
+        INSTALLED_RETROFY=$(/tmp/editable-venv/bin/pip list --format=freeze | grep -E '^retrofy==' | head -n1)
+        echo "Confirmed editable install pulled ${INSTALLED_RETROFY}"
 
     - name: Test example-project from isolation (editable install)
       run: |
         cd not-the-source
         /tmp/editable-venv/bin/pytest --pyargs example_project -ssvv
+
+    - name: Install example-project as editable with uv
+      run: |
+        # Mirror of the pip editable step, exercising uv's PEP 660
+        # implementation. uv follows PEP 621 strictly: it will only
+        # call the backend's ``prepare_metadata_for_build_editable``
+        # hook (and thus see retrofy's spliced ``Requires-Dist``) when
+        # the project declares ``dependencies`` in ``[project].dynamic``
+        # — which example-project does. If uv ever stops calling the
+        # backend hook, or if example-project drops the ``dynamic``
+        # declaration, this step regresses and the retrofy assertion
+        # below fails.
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
+        uv --version
+
+        uv venv --python ${{ matrix.python-version }} /tmp/editable-uv-venv
+
+        # Feed uv the dev wheels for both build- and runtime resolution.
+        export UV_FIND_LINKS="${{ github.workspace }}/dist"
+        VIRTUAL_ENV=/tmp/editable-uv-venv uv pip install pytest
+        VIRTUAL_ENV=/tmp/editable-uv-venv uv pip install \
+          --editable example-project/ \
+          --build-constraint /tmp/retrofy-build-constraint.txt \
+          --constraint /tmp/retrofy-build-constraint.txt
+
+        if ! VIRTUAL_ENV=/tmp/editable-uv-venv uv pip list --format=freeze \
+            | grep -qE '^retrofy=='; then
+          echo "::error::uv editable install did not pull retrofy as a runtime dep — uv may have stopped honouring prepare_metadata_for_build_editable, or example-project lost its 'dynamic = [\"dependencies\"]' declaration"
+          VIRTUAL_ENV=/tmp/editable-uv-venv uv pip list --format=freeze
+          exit 1
+        fi
+        INSTALLED_RETROFY=$(VIRTUAL_ENV=/tmp/editable-uv-venv uv pip list --format=freeze | grep -E '^retrofy==' | head -n1)
+        echo "Confirmed uv editable install pulled ${INSTALLED_RETROFY}"
+
+    - name: Test example-project from isolation (uv editable install)
+      run: |
+        cd not-the-source
+        /tmp/editable-uv-venv/bin/pytest --pyargs example_project -ssvv
 
   compatibility_test:
     strategy:

--- a/example-project/pyproject.toml
+++ b/example-project/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["multistage-build", "setuptools", "retrofy"]
+requires = ["multistage-build>=0.2", "setuptools", "retrofy"]
 build-backend = "multistage_build:backend"
 
 [tool.multistage-build]
@@ -11,6 +11,11 @@ version = "0.1"
 description = "A project full of the latest and greatest Python (syntax) features"
 # The syntax in the repository is Python 3.13+, but we use retrofy to support older versions.
 requires-python = ">=3.7"
+# Retrofy injects ``Requires-Dist: retrofy`` for editable installs (it
+# needs retrofy at runtime for the import-time rewriter). PEP 621
+# requires this to be opted into via ``dynamic``; wheel installs are
+# unaffected.
+dynamic = ["dependencies"]
 
 [project.optional-dependencies]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ Homepage = "https://github.com/pelson/retrofy"
 # Declare automatic hooks for a multistage-build using project.
 post-build-wheel = "retrofy._pep517_hooks:compatibility_via_rewrite"
 post-build-editable = "retrofy._pep517_hooks:compatibility_via_import_hook"
+post-prepare-metadata-for-build-editable = "retrofy._pep517_hooks:inject_runtime_requirement"
 
 [project.entry-points.pytest11]
 # Cooperate with pytest's assertion rewriter when test files use

--- a/retrofy/_pep517_hooks.py
+++ b/retrofy/_pep517_hooks.py
@@ -18,13 +18,7 @@ else:
 class EditableRuntimeRequirementError(RuntimeError):
     """The project being built editable has not marked ``dependencies``
     as ``dynamic``, so retrofy cannot legitimately inject itself as a
-    runtime requirement. Frontends that follow PEP 621 strictly (e.g.
-    uv) would then refuse to install retrofy, and the rewritten source
-    would fail at import time.
-
-    This check fires only on the editable build path. Wheel builds bake
-    the converted source into the wheel and do not need retrofy at
-    runtime, so they impose no such requirement.
+    runtime requirement.
     """
 
 
@@ -46,29 +40,19 @@ def _assert_editable_dependencies_dynamic(source_root: pathlib.Path) -> None:
         "Editable installs of retrofy-using projects need retrofy at "
         "runtime, but this project's pyproject.toml does not mark "
         "``dependencies`` as dynamic, so retrofy cannot inject itself "
-        "as a runtime requirement in a PEP 621-compliant way (uv, in "
-        "particular, will refuse to call the backend's metadata hook "
-        "otherwise).\n\n"
+        "as a runtime requirement in a PEP 621-compliant way.\n\n"
         "Add the following to pyproject.toml:\n\n"
         "    [project]\n"
         '    dynamic = ["dependencies"]\n\n'
-        "Wheel builds of the same project are unaffected and impose no "
-        "such requirement.",
+        "Non-editable builds of the same project are unaffected and "
+        "impose no such requirement.",
     )
 
 
 def _splice_retrofy_requires_dist(text: str) -> str:
-    """Return ``text`` with ``Requires-Dist: retrofy`` added to the
-    METADATA header block, or return ``text`` unchanged if it already
-    declares a retrofy requirement.
+    """Return ``text`` with an unconditional ``Requires-Dist: retrofy``
+    added to the METADATA header block.
     """
-    if any(
-        line.strip().lower() == "requires-dist: retrofy"
-        or line.strip().lower().startswith("requires-dist: retrofy ")
-        or line.strip().lower().startswith("requires-dist: retrofy;")
-        for line in text.splitlines()
-    ):
-        return text
     # PEP 566 / RFC 822: the first blank line ends the header block and
     # starts the long-description body. The new Requires-Dist must go
     # inside the header block.

--- a/retrofy/_pep517_hooks.py
+++ b/retrofy/_pep517_hooks.py
@@ -1,10 +1,96 @@
+from __future__ import annotations
+
 import pathlib
 import shutil
+import sys
 import zipfile
 
 from setuptools_ext import WheelModifier
 
 from ._converters import convert
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+class EditableRuntimeRequirementError(RuntimeError):
+    """The project being built editable has not marked ``dependencies``
+    as ``dynamic``, so retrofy cannot legitimately inject itself as a
+    runtime requirement. Frontends that follow PEP 621 strictly (e.g.
+    uv) would then refuse to install retrofy, and the rewritten source
+    would fail at import time.
+
+    This check fires only on the editable build path. Wheel builds bake
+    the converted source into the wheel and do not need retrofy at
+    runtime, so they impose no such requirement.
+    """
+
+
+def _assert_editable_dependencies_dynamic(source_root: pathlib.Path) -> None:
+    """Raise ``EditableRuntimeRequirementError`` unless the project at
+    ``source_root`` lists ``dependencies`` in ``[project].dynamic``,
+    which is what lets this backend splice ``Requires-Dist: retrofy``
+    into the editable METADATA in a PEP 621-compliant way.
+    """
+    pyproject = source_root / "pyproject.toml"
+    if not pyproject.exists():
+        return
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    dynamic = project.get("dynamic", []) or []
+    if "dependencies" in dynamic:
+        return
+    raise EditableRuntimeRequirementError(
+        "Editable installs of retrofy-using projects need retrofy at "
+        "runtime, but this project's pyproject.toml does not mark "
+        "``dependencies`` as dynamic, so retrofy cannot inject itself "
+        "as a runtime requirement in a PEP 621-compliant way (uv, in "
+        "particular, will refuse to call the backend's metadata hook "
+        "otherwise).\n\n"
+        "Add the following to pyproject.toml:\n\n"
+        "    [project]\n"
+        '    dynamic = ["dependencies"]\n\n'
+        "Wheel builds of the same project are unaffected and impose no "
+        "such requirement.",
+    )
+
+
+def _splice_retrofy_requires_dist(text: str) -> str:
+    """Return ``text`` with ``Requires-Dist: retrofy`` added to the
+    METADATA header block, or return ``text`` unchanged if it already
+    declares a retrofy requirement.
+    """
+    if any(
+        line.strip().lower() == "requires-dist: retrofy"
+        or line.strip().lower().startswith("requires-dist: retrofy ")
+        or line.strip().lower().startswith("requires-dist: retrofy;")
+        for line in text.splitlines()
+    ):
+        return text
+    # PEP 566 / RFC 822: the first blank line ends the header block and
+    # starts the long-description body. The new Requires-Dist must go
+    # inside the header block.
+    header, sep, body = text.partition("\n\n")
+    header = header.rstrip("\n")
+    suffix = sep + body if sep else "\n"
+    return header + "\nRequires-Dist: retrofy" + suffix
+
+
+def inject_runtime_requirement(dist_info_path: pathlib.Path) -> None:
+    """``post-prepare-metadata-for-build-editable`` hook.
+
+    Editable installs of a retrofy-using project keep their original
+    source on disk and rely on retrofy's import-time rewriter, so retrofy
+    must be present at runtime. Splice ``Requires-Dist: retrofy`` into
+    the prepared ``METADATA`` so pip resolves it as a runtime dep.
+    """
+    metadata_path = dist_info_path / "METADATA"
+    text = metadata_path.read_text(encoding="utf-8")
+    new_text = _splice_retrofy_requires_dist(text)
+    if new_text != text:
+        metadata_path.write_text(new_text, encoding="utf-8")
 
 
 def compatibility_via_import_hook(wheel: pathlib.Path):
@@ -13,6 +99,8 @@ def compatibility_via_import_hook(wheel: pathlib.Path):
     (i.e. suitable for editable mode)
 
     """
+    _assert_editable_dependencies_dynamic(pathlib.Path.cwd())
+
     editable_copy = wheel.parent / (wheel.name + ".copy.whl")
     shutil.copy(wheel, editable_copy)
 
@@ -35,13 +123,19 @@ def compatibility_via_import_hook(wheel: pathlib.Path):
             )
             whl.write(zipfile.ZipInfo(fn), script)
 
+        # Mirror the prepare_metadata_for_build_editable splice into the
+        # final wheel so the installed dist-info also advertises retrofy
+        # as a runtime dep.
+        metadata_name = whl.dist_info_dirname() + "/METADATA"
+        metadata_text = whl.read(metadata_name).decode("utf-8")
+        new_metadata = _splice_retrofy_requires_dist(metadata_text)
+        if new_metadata != metadata_text:
+            whl.write(metadata_name, new_metadata)
+
         with wheel.open("wb") as whl_fh:
             whl.write_wheel(whl_fh)
 
     print("Enabling automatic retrofiting of Python code at import-time")
-
-    # TODO: I think we need to add retrofy as a runtime dependency for editable mode
-    #  (we can do this).
 
     editable_copy.unlink()
 

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import pathlib
+import textwrap
+
+import pytest
+
+from retrofy._pep517_hooks import (
+    EditableRuntimeRequirementError,
+    _assert_editable_dependencies_dynamic,
+    inject_runtime_requirement,
+)
+
+
+def _write_metadata(tmp_path: pathlib.Path, body: str) -> pathlib.Path:
+    dist_info = tmp_path / "some_project-0.1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(textwrap.dedent(body), encoding="utf-8")
+    return dist_info
+
+
+def test_inject_runtime_requirement_adds_dep(tmp_path):
+    dist_info = _write_metadata(
+        tmp_path,
+        """\
+        Metadata-Version: 2.1
+        Name: some-project
+        Version: 0.1.0
+        Requires-Dist: libcst
+
+        Some long description.
+        """,
+    )
+    inject_runtime_requirement(dist_info)
+    text = (dist_info / "METADATA").read_text(encoding="utf-8")
+    assert "Requires-Dist: retrofy\n" in text
+    assert "Requires-Dist: libcst\n" in text
+    assert text.endswith("Some long description.\n")
+    # The line must land inside the header block (before the blank line),
+    # otherwise pip parses it as part of the description.
+    header, _, _ = text.partition("\n\n")
+    assert "Requires-Dist: retrofy" in header
+
+
+def test_inject_runtime_requirement_is_idempotent(tmp_path):
+    dist_info = _write_metadata(
+        tmp_path,
+        """\
+        Metadata-Version: 2.1
+        Name: some-project
+        Version: 0.1.0
+        Requires-Dist: retrofy
+
+        Body.
+        """,
+    )
+    before = (dist_info / "METADATA").read_text(encoding="utf-8")
+    inject_runtime_requirement(dist_info)
+    assert (dist_info / "METADATA").read_text(encoding="utf-8") == before
+
+
+def test_inject_runtime_requirement_skips_when_retrofy_has_marker(tmp_path):
+    dist_info = _write_metadata(
+        tmp_path,
+        """\
+        Metadata-Version: 2.1
+        Name: some-project
+        Version: 0.1.0
+        Requires-Dist: retrofy; python_version < "3.12"
+
+        Body.
+        """,
+    )
+    before = (dist_info / "METADATA").read_text(encoding="utf-8")
+    inject_runtime_requirement(dist_info)
+    assert (dist_info / "METADATA").read_text(encoding="utf-8") == before
+
+
+def test_inject_runtime_requirement_no_body(tmp_path):
+    dist_info = _write_metadata(
+        tmp_path,
+        """\
+        Metadata-Version: 2.1
+        Name: some-project
+        Version: 0.1.0
+        """,
+    )
+    inject_runtime_requirement(dist_info)
+    text = (dist_info / "METADATA").read_text(encoding="utf-8")
+    assert "Requires-Dist: retrofy" in text
+
+
+def _write_pyproject(tmp_path: pathlib.Path, body: str) -> pathlib.Path:
+    (tmp_path / "pyproject.toml").write_text(textwrap.dedent(body), encoding="utf-8")
+    return tmp_path
+
+
+def test_assert_editable_dependencies_dynamic_passes_when_dynamic(tmp_path):
+    root = _write_pyproject(
+        tmp_path,
+        """\
+        [project]
+        name = "some-project"
+        version = "0.1"
+        dynamic = ["dependencies"]
+        """,
+    )
+    _assert_editable_dependencies_dynamic(root)
+
+
+def test_assert_editable_dependencies_dynamic_raises_when_static(tmp_path):
+    root = _write_pyproject(
+        tmp_path,
+        """\
+        [project]
+        name = "some-project"
+        version = "0.1"
+        dependencies = ["retrofy"]
+        """,
+    )
+    with pytest.raises(EditableRuntimeRequirementError, match="dynamic"):
+        _assert_editable_dependencies_dynamic(root)
+
+
+def test_assert_editable_dependencies_dynamic_raises_when_absent(tmp_path):
+    root = _write_pyproject(
+        tmp_path,
+        """\
+        [project]
+        name = "some-project"
+        version = "0.1"
+        """,
+    )
+    with pytest.raises(EditableRuntimeRequirementError):
+        _assert_editable_dependencies_dynamic(root)
+
+
+def test_assert_editable_dependencies_dynamic_skips_when_no_pyproject(tmp_path):
+    _assert_editable_dependencies_dynamic(tmp_path)

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -42,24 +42,10 @@ def test_inject_runtime_requirement_adds_dep(tmp_path):
     assert "Requires-Dist: retrofy" in header
 
 
-def test_inject_runtime_requirement_is_idempotent(tmp_path):
-    dist_info = _write_metadata(
-        tmp_path,
-        """\
-        Metadata-Version: 2.1
-        Name: some-project
-        Version: 0.1.0
-        Requires-Dist: retrofy
-
-        Body.
-        """,
-    )
-    before = (dist_info / "METADATA").read_text(encoding="utf-8")
-    inject_runtime_requirement(dist_info)
-    assert (dist_info / "METADATA").read_text(encoding="utf-8") == before
-
-
-def test_inject_runtime_requirement_skips_when_retrofy_has_marker(tmp_path):
+def test_inject_runtime_requirement_adds_even_if_retrofy_already_present(tmp_path):
+    # A pre-existing retrofy line may carry environment markers that
+    # leave the running interpreter without retrofy installed, so we
+    # add an unconditional line regardless. Pip dedupes the rest.
     dist_info = _write_metadata(
         tmp_path,
         """\
@@ -71,9 +57,16 @@ def test_inject_runtime_requirement_skips_when_retrofy_has_marker(tmp_path):
         Body.
         """,
     )
-    before = (dist_info / "METADATA").read_text(encoding="utf-8")
     inject_runtime_requirement(dist_info)
-    assert (dist_info / "METADATA").read_text(encoding="utf-8") == before
+    text = (dist_info / "METADATA").read_text(encoding="utf-8")
+    header, _, _ = text.partition("\n\n")
+    lines = [
+        line
+        for line in header.splitlines()
+        if line.startswith("Requires-Dist: retrofy")
+    ]
+    assert len(lines) == 2
+    assert "Requires-Dist: retrofy" in lines
 
 
 def test_inject_runtime_requirement_no_body(tmp_path):


### PR DESCRIPTION
Editable installs of retrofy-using projects rewrite source at import time, so retrofy must be importable at runtime. Until now, the example-project CI worked around this with a manual ``pip install retrofy`` after the editable install.

This change closes the gap properly by routing retrofy through a new ``post-prepare-metadata-for-build-editable`` hook (added upstream in multistage-build 0.2): ``inject_runtime_requirement`` splices ``Requires-Dist: retrofy`` into the prepared METADATA that pip (and any spec-compliant frontend) uses for resolution. The same splice is also applied to the editable wheel inside ``compatibility_via_import_hook`` so the installed dist-info advertises the dep to ``pip show`` and inspection tools.

Because PEP 621 forbids backends from materialising fields that the project didn't mark dynamic, the build-editable hook now refuses to proceed unless the project declares ``dynamic = ["dependencies"]`` — otherwise strict frontends (uv) would silently fail to install retrofy. Wheel builds are unaffected: the converted source has no runtime retrofy dependency.

example-project opts in via ``dynamic = ["dependencies"]`` and pins ``multistage-build>=0.2``. CI now asserts (on both pip and uv editable paths) that retrofy IS pulled in as a runtime dep.