### PR TITLE
Lower sdists alongside wheels via post-build-sdist hook

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -41,7 +41,7 @@ jobs:
         RETROFY_DISABLE_REWRITE: "1"
       run: |
         python -m pip install --upgrade pip
-        python -m pip install build multistage-build setuptools_scm libcst setuptools-ext tomli
+        python -m pip install build multistage-build setuptools_scm libcst setuptools-ext tomli tomlkit packaging
         python -m pip install . --no-build-isolation --no-deps
 
     - name: Build wheel and sdist (lowered)

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -41,7 +41,22 @@ jobs:
         RETROFY_DISABLE_REWRITE: "1"
       run: |
         python -m pip install --upgrade pip
-        python -m pip install build multistage-build setuptools_scm libcst setuptools-ext tomli tomlkit packaging
+        python -m pip install build
+        # ``pip install . --no-build-isolation --no-deps`` needs both
+        # [build-system].requires and [project].dependencies already
+        # present in the env: --no-build-isolation cascades to
+        # transitively-built sdists, so on interpreters that lack a
+        # binary wheel for a dep (e.g. libcst on 3.15-beta) that dep's
+        # own source build would inherit --no-build-isolation and fail
+        # on its build requirements. Install both lists in one pip
+        # call with build isolation ON so each sdist-built dep still
+        # gets its own clean build env; then install retrofy with
+        # --no-deps. Derive the list from pyproject.toml so it stays
+        # in one place, dropping retrofy's own self-reference.
+        python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print('\n'.join(r for r in d['build-system']['requires'] + d['project']['dependencies'] if not r.startswith('retrofy')))" \
+          > /tmp/build-and-run-dependencies.txt
+        cat /tmp/build-and-run-dependencies.txt
+        python -m pip install -r /tmp/build-and-run-dependencies.txt
         python -m pip install . --no-build-isolation --no-deps
 
     - name: Build wheel and sdist (lowered)
@@ -312,6 +327,14 @@ jobs:
         /tmp/sdist-example-venv/bin/pip install pytest
         /tmp/sdist-example-venv/bin/pip install example-project/sdist/*.tar.gz
 
+        # Sanity that the freeze/grep check itself works: the sdist we
+        # just installed must show up in the venv. A no-match here
+        # means the retrofy-absence check below is a false negative.
+        if ! /tmp/sdist-example-venv/bin/pip list --format=freeze | grep -qE '^retrofy-test-project=='; then
+          echo "::error::retrofy-test-project not found in /tmp/sdist-example-venv — the sdist install did not take, and the retrofy-absence check below would be a false negative"
+          /tmp/sdist-example-venv/bin/pip list --format=freeze
+          exit 1
+        fi
         if /tmp/sdist-example-venv/bin/pip list --format=freeze | grep -qE '^retrofy=='; then
           echo "::error::retrofy unexpectedly installed in /tmp/sdist-example-venv — lower_sdist did not strip it from build-system.requires"
           /tmp/sdist-example-venv/bin/pip list --format=freeze | grep -E '^retrofy'
@@ -509,15 +532,9 @@ jobs:
         # carries the backend chain (retrofy, multistage-build,
         # setuptools); ``--no-deps`` so pip doesn't try to install
         # example-project's deps into the wheel-build dir.
-        # ``--ignore-requires-python`` because example-project declares
-        # ``requires-python = ">=3.15"`` (the on-disk source syntax),
-        # but the converter Python is 3.13. pip would otherwise refuse
-        # to build; the actual install target -- the host venv below --
-        # uses the *lowered* wheel, whose Requires-Python is set from
-        # ``[tool.retrofy] target-python``.
         mkdir -p /tmp/expr-dist
         "$HOME/.cache/retrofy/converter-venv/bin/pip" wheel ./example-project \
-          --no-build-isolation --no-deps --ignore-requires-python \
+          --no-build-isolation --no-deps \
           --wheel-dir /tmp/expr-dist
 
     - name: Install + test example-project wheel on the host

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -210,6 +210,10 @@ jobs:
         /tmp/sdist-venv/bin/pip install --upgrade pip
         RETROFY_SDIST=$(ls dist/retrofy-*.tar.gz)
         /tmp/sdist-venv/bin/pip install "$RETROFY_SDIST"
+        # ``cd /tmp`` to dodge cwd-first import shadowing -- the
+        # checkout's ``retrofy/`` source has no setuptools-scm
+        # ``_version.py`` and would mask the installed dist.
+        cd /tmp
         /tmp/sdist-venv/bin/python -c "import retrofy; print(retrofy.__version__)"
 
     - name: Build example-project (exercises the retrofy build rewrite)
@@ -505,9 +509,16 @@ jobs:
         # carries the backend chain (retrofy, multistage-build,
         # setuptools); ``--no-deps`` so pip doesn't try to install
         # example-project's deps into the wheel-build dir.
+        # ``--ignore-requires-python`` because example-project declares
+        # ``requires-python = ">=3.15"`` (the on-disk source syntax),
+        # but the converter Python is 3.13. pip would otherwise refuse
+        # to build; the actual install target -- the host venv below --
+        # uses the *lowered* wheel, whose Requires-Python is set from
+        # ``[tool.retrofy] target-python``.
         mkdir -p /tmp/expr-dist
         "$HOME/.cache/retrofy/converter-venv/bin/pip" wheel ./example-project \
-          --no-build-isolation --no-deps --wheel-dir /tmp/expr-dist
+          --no-build-isolation --no-deps --ignore-requires-python \
+          --wheel-dir /tmp/expr-dist
 
     - name: Install + test example-project wheel on the host
       run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -199,6 +199,24 @@ jobs:
         cd not-the-source
         python -m pytest --pyargs retrofy -ssvv
 
+    - name: Install retrofy from its own lowered sdist (build-via-sdist smoke)
+      run: |
+        # The build job runs ``lower_sdist`` against retrofy's own sdist;
+        # this step exercises the resulting tarball end-to-end on the
+        # matrix Python. It catches breakage in the sdist's pyproject
+        # rewrite (e.g. bad TOML emission, multi-line array mangling,
+        # nested ``]``) that the wheel-install path above cannot see.
+        #
+        # No ``PIP_BUILD_CONSTRAINT`` is needed: ``lower_sdist`` strips
+        # retrofy from ``[build-system].requires``, so the build-
+        # isolation env never tries to install retrofy and the
+        # build-from-sdist succeeds with no retrofy on the host.
+        python -m venv /tmp/sdist-venv
+        /tmp/sdist-venv/bin/pip install --upgrade pip
+        RETROFY_SDIST=$(ls dist/retrofy-*.tar.gz)
+        /tmp/sdist-venv/bin/pip install "$RETROFY_SDIST"
+        /tmp/sdist-venv/bin/python -c "import retrofy; print(retrofy.__version__)"
+
     - name: Build example-project (exercises the retrofy build rewrite)
       run: |
         # Build with pip's build isolation (mirrors how end users build
@@ -270,6 +288,49 @@ jobs:
       run: |
         cd not-the-source
         /tmp/wheel-venv/bin/pytest --pyargs example_project -ssvv
+
+    - name: Build example-project sdist (exercises retrofy's lower_sdist hook)
+      run: |
+        # ``pip wheel`` only produces wheels, so for sdists we use
+        # ``python -m build``. To avoid ``build``'s default fresh-venv
+        # path (whose ensurepip-bundled pip is too old to honour
+        # ``PIP_BUILD_CONSTRAINT`` and would silently drift to released
+        # retrofy), set up a dedicated builder venv, install the dev
+        # retrofy into it from the local index, and run ``build
+        # --no-isolation`` so it reuses that venv as the build env.
+        mkdir -p example-project/sdist
+        python -m venv /tmp/sdist-builder
+        /tmp/sdist-builder/bin/pip install --upgrade pip
+        # PIP_INDEX_URL is exported by the merged-index step; the dev
+        # retrofy resolves locally, all other deps resolve from PyPI.
+        /tmp/sdist-builder/bin/pip install \
+          build multistage-build setuptools setuptools_scm retrofy
+        /tmp/sdist-builder/bin/python -m build --sdist --no-isolation \
+          --outdir example-project/sdist ./example-project
+        ls example-project/sdist/
+
+    - name: Install built example-project sdist in a fresh venv
+      run: |
+        # The lowered sdist must install on the matrix Python without
+        # retrofy in the build environment (lower_sdist strips retrofy
+        # from [build-system].requires). A failure here means the
+        # sdist's pyproject is malformed or the lowered source still
+        # contains post-3.9 syntax.
+        python -m venv /tmp/sdist-example-venv
+        /tmp/sdist-example-venv/bin/pip install --upgrade pip
+        /tmp/sdist-example-venv/bin/pip install pytest
+        /tmp/sdist-example-venv/bin/pip install example-project/sdist/*.tar.gz
+
+        if /tmp/sdist-example-venv/bin/pip list --format=freeze | grep -qE '^retrofy=='; then
+          echo "::error::retrofy unexpectedly installed in /tmp/sdist-example-venv — lower_sdist did not strip it from build-system.requires"
+          /tmp/sdist-example-venv/bin/pip list --format=freeze | grep -E '^retrofy'
+          exit 1
+        fi
+
+    - name: Test example-project from isolation (sdist install)
+      run: |
+        cd not-the-source
+        /tmp/sdist-example-venv/bin/pytest --pyargs example_project -ssvv
 
     - name: Install example-project as editable in a fresh venv
       run: |
@@ -365,12 +426,9 @@ jobs:
         # ``--no-project`` + ``--with-editable .`` mode rather than
         # full project mode because the latter would try to produce a
         # universal ``uv.lock`` across example-project's whole
-        # ``requires-python`` range (>=3.7), which is unsatisfiable —
-        # retrofy itself requires >=3.9, so editable installs simply
-        # cannot resolve for Python 3.7 / 3.8 (non-editable wheel
-        # installs of example-project still work on 3.7+). The
-        # ``--no-project`` path resolves only for the active
-        # interpreter and writes no lockfile.
+        # ``requires-python`` range, which adds matrix overhead for no
+        # benefit here. The ``--no-project`` path resolves only for the
+        # active interpreter and writes no lockfile.
         #
         # ``UV_BUILD_CONSTRAINT`` / ``UV_CONSTRAINT`` are NOT honoured by
         # ``uv run`` (only by ``uv pip install``), so we can't pin the

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -201,16 +201,11 @@ jobs:
 
     - name: Install retrofy from its own lowered sdist (build-via-sdist smoke)
       run: |
-        # The build job runs ``lower_sdist`` against retrofy's own sdist;
-        # this step exercises the resulting tarball end-to-end on the
-        # matrix Python. It catches breakage in the sdist's pyproject
-        # rewrite (e.g. bad TOML emission, multi-line array mangling,
-        # nested ``]``) that the wheel-install path above cannot see.
-        #
-        # No ``PIP_BUILD_CONSTRAINT`` is needed: ``lower_sdist`` strips
-        # retrofy from ``[build-system].requires``, so the build-
-        # isolation env never tries to install retrofy and the
-        # build-from-sdist succeeds with no retrofy on the host.
+        # Exercise ``lower_sdist`` end-to-end on the matrix Python. Builds
+        # retrofy from its own sdist into a fresh venv; catches breakage
+        # in the sdist's pyproject rewrite (bad TOML emission, multi-line
+        # array mangling, nested ``]``) that the wheel-install path above
+        # cannot see.
         python -m venv /tmp/sdist-venv
         /tmp/sdist-venv/bin/pip install --upgrade pip
         RETROFY_SDIST=$(ls dist/retrofy-*.tar.gz)
@@ -291,22 +286,14 @@ jobs:
 
     - name: Build example-project sdist (exercises retrofy's lower_sdist hook)
       run: |
-        # ``pip wheel`` only produces wheels, so for sdists we use
-        # ``python -m build``. To avoid ``build``'s default fresh-venv
-        # path (whose ensurepip-bundled pip is too old to honour
-        # ``PIP_BUILD_CONSTRAINT`` and would silently drift to released
-        # retrofy), set up a dedicated builder venv, install the dev
-        # retrofy into it from the local index, and run ``build
-        # --no-isolation`` so it reuses that venv as the build env.
+        # ``python -m build --sdist`` with default build isolation. The
+        # build-env pip honours ``PIP_INDEX_URL`` (set earlier to the
+        # merged local+PyPI simple-repository server), so retrofy
+        # resolves to the dev wheel from ``dist/`` and everything else
+        # falls through to PyPI.
         mkdir -p example-project/sdist
-        python -m venv /tmp/sdist-builder
-        /tmp/sdist-builder/bin/pip install --upgrade pip
-        # PIP_INDEX_URL is exported by the merged-index step; the dev
-        # retrofy resolves locally, all other deps resolve from PyPI.
-        /tmp/sdist-builder/bin/pip install \
-          build multistage-build setuptools setuptools_scm retrofy
-        /tmp/sdist-builder/bin/python -m build --sdist --no-isolation \
-          --outdir example-project/sdist ./example-project
+        python -m pip install build
+        python -m build --sdist --outdir example-project/sdist ./example-project
         ls example-project/sdist/
 
     - name: Install built example-project sdist in a fresh venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://gitlab.cern.ch/pre-commit-hook-mirrors/pre-commit/mirrors-mypy
-    rev: 'v1.4.1'
+    rev: 'v1.18.2'
     hooks:
       - id: mypy
         additional_dependencies: ["types-mock"]

--- a/example-project/pyproject.toml
+++ b/example-project/pyproject.toml
@@ -10,7 +10,7 @@ name = "retrofy-test-project"
 version = "0.1"
 description = "A project full of the latest and greatest Python (syntax) features"
 # The syntax in the repository is Python 3.13+, but we use retrofy to support older versions.
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 # Retrofy injects ``Requires-Dist: retrofy`` for editable installs (it
 # needs retrofy at runtime for the import-time rewriter). PEP 621
 # requires this to be opted into via ``dynamic``; wheel installs are

--- a/example-project/pyproject.toml
+++ b/example-project/pyproject.toml
@@ -9,8 +9,11 @@ build-backend = "setuptools.build_meta"
 name = "retrofy-test-project"
 version = "0.1"
 description = "A project full of the latest and greatest Python (syntax) features"
-# The syntax in the repository is Python 3.13+, but we use retrofy to support older versions.
-requires-python = ">=3.9"
+# Declares the Python version the on-disk *source* needs. The source
+# uses PEP 810 ``lazy from`` and other 3.15+ syntax; retrofy's
+# ``post-build-wheel`` / ``post-build-sdist`` hooks lower this floor
+# in the built artefacts according to ``[tool.retrofy] target-python``.
+requires-python = ">=3.15"
 # Retrofy injects ``Requires-Dist: retrofy`` for editable installs (it
 # needs retrofy at runtime for the import-time rewriter). PEP 621
 # requires this to be opted into via ``dynamic``; wheel installs are
@@ -32,8 +35,9 @@ include = ["example_project", "example_project.*"]
 [tool.retrofy]
 # Target floor for both the lowered wheel (post-build-wheel) and the
 # lowered sdist (post-build-sdist). The on-disk source is 3.15+;
-# retrofy rewrites both artefacts so they install on 3.9+.
-target-python = "3.9"
+# retrofy rewrites both artefacts so they install on the floor below.
+# Set deliberately broad to exercise retrofy's lowering reach.
+target-python = "3.7"
 
 # The on-disk source uses post-current-Python syntax that retrofy
 # backports at build / import time. Tell ruff to lint it against the

--- a/example-project/pyproject.toml
+++ b/example-project/pyproject.toml
@@ -29,6 +29,12 @@ dev = [
 [tool.setuptools.packages.find]
 include = ["example_project", "example_project.*"]
 
+[tool.retrofy]
+# Target floor for both the lowered wheel (post-build-wheel) and the
+# lowered sdist (post-build-sdist). The on-disk source is 3.15+;
+# retrofy rewrites both artefacts so they install on 3.9+.
+target-python = "3.9"
+
 # The on-disk source uses post-current-Python syntax that retrofy
 # backports at build / import time. Tell ruff to lint it against the
 # Python version where that syntax is native, not the ``requires-python``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
   "libcst",
   "setuptools-ext",  # TODO: Get rid of this dependency when there is a wheel interface elsewhere.
   "tomli; python_version < '3.11'",
+  # tomlkit drives the sdist-lowering pyproject rewrite (round-trip
+  # TOML preserves multi-line arrays, nested ``]``, and user comments
+  # that the previous regex approach mangled).
+  "tomlkit",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
   # TOML preserves multi-line arrays, nested ``]``, and user comments
   # that the previous regex approach mangled).
   "tomlkit",
+  # packaging.Requirement / canonicalize_name parse PEP 508 specs in
+  # ``[build-system].requires`` when ``lower_sdist`` strips retrofy.
+  "packaging",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,7 @@ dependencies = [
   "libcst",
   "setuptools-ext",  # TODO: Get rid of this dependency when there is a wheel interface elsewhere.
   "tomli; python_version < '3.11'",
-  # tomlkit drives the sdist-lowering pyproject rewrite (round-trip
-  # TOML preserves multi-line arrays, nested ``]``, and user comments
-  # that the previous regex approach mangled).
   "tomlkit",
-  # packaging.Requirement / canonicalize_name parse PEP 508 specs in
-  # ``[build-system].requires`` when ``lower_sdist`` strips retrofy.
   "packaging",
 ]
 
@@ -65,6 +60,7 @@ post-build-wheel = "retrofy._pep517_hooks:compatibility_via_rewrite"
 post-build-sdist = "retrofy._pep517_hooks:lower_sdist"
 post-build-editable = "retrofy._pep517_hooks:compatibility_via_import_hook"
 post-prepare-metadata-for-build-editable = "retrofy._pep517_hooks:inject_runtime_requirement"
+post-prepare-metadata-for-build-wheel = "retrofy._pep517_hooks:lower_metadata_requires_python"
 
 [project.entry-points.pytest11]
 # Cooperate with pytest's assertion rewriter when test files use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ Homepage = "https://github.com/pelson/retrofy"
 [project.entry-points.multistage_build]
 # Declare automatic hooks for a multistage-build using project.
 post-build-wheel = "retrofy._pep517_hooks:compatibility_via_rewrite"
+post-build-sdist = "retrofy._pep517_hooks:lower_sdist"
 post-build-editable = "retrofy._pep517_hooks:compatibility_via_import_hook"
 post-prepare-metadata-for-build-editable = "retrofy._pep517_hooks:inject_runtime_requirement"
 

--- a/retrofy/_pep517_hooks.py
+++ b/retrofy/_pep517_hooks.py
@@ -13,6 +13,7 @@ import tempfile
 import zipfile
 
 from setuptools_ext import WheelModifier
+import tomlkit
 
 from ._converters import convert
 
@@ -94,13 +95,13 @@ def _assert_editable_dependencies_dynamic(source_root: pathlib.Path) -> None:
 
 
 def _read_target_python(source_root: pathlib.Path) -> str | None:
-    """Return the ``Requires-Python`` specifier requested by the project
-    at ``source_root`` via ``[tool.retrofy] target-python``, or ``None``
-    if the project does not opt in.
+    """Return the bare floor (e.g. ``"3.9"``) requested by the project at
+    ``source_root`` via ``[tool.retrofy] target-python``, or ``None`` if
+    the project does not opt in.
 
-    The value in pyproject is a bare floor (e.g. ``"3.9"``); the returned
-    string is a PEP 440 specifier (``">=3.9"``) suitable for splicing
-    into METADATA verbatim.
+    Callers format the floor into a PEP 440 specifier (``">=3.9"``)
+    themselves -- the bare value matches what users write in pyproject
+    and avoids a round-trip strip at every consumer.
     """
     pyproject = source_root / "pyproject.toml"
     if not pyproject.exists():
@@ -116,7 +117,7 @@ def _read_target_python(source_root: pathlib.Path) -> str | None:
             f"pyproject.toml -- TOML floats like ``3.10`` lose their "
             f"trailing zero and silently lower the floor.",
         )
-    return f">={floor}"
+    return floor
 
 
 def _retrofy_version() -> str:
@@ -314,17 +315,18 @@ def compatibility_via_rewrite(wheel: pathlib.Path):
                 )
                 has_modifications = True
 
-        target_py = _read_target_python(pathlib.Path.cwd())
-        if target_py is not None:
+        floor = _read_target_python(pathlib.Path.cwd())
+        if floor is not None:
+            spec = f">={floor}"
             metadata_name = whl.dist_info_dirname() + "/METADATA"
             metadata_text = whl.read(metadata_name).decode("utf-8")
-            new_metadata = _lower_requires_python(metadata_text, target_py)
+            new_metadata = _lower_requires_python(metadata_text, spec)
             if new_metadata != metadata_text:
                 whl.write(metadata_name, new_metadata)
                 _log.info(
                     "Lowered Requires-Python in %s to %s",
                     metadata_name,
-                    target_py,
+                    spec,
                 )
                 has_modifications = True
 
@@ -368,164 +370,52 @@ def _build_requires_drop_retrofy(requires: list[str]) -> list[str]:
 
 
 def _patch_pyproject_for_lowered_sdist(text: str, floor: str) -> str:
-    """Patch a sdist's ``pyproject.toml`` text for the lowered sdist:
+    """Patch a sdist's ``pyproject.toml`` for the lowered sdist:
 
     - rewrite ``[project].requires-python`` to ``>={floor}``; if
       ``requires-python`` was in ``[project].dynamic``, drop it.
-    - drop ``retrofy`` from ``[build-system].requires``.
+    - drop ``retrofy`` from ``[build-system].requires`` (PEP 503
+      normalised match).
 
-    Implementation note: round-tripping TOML losslessly is hard, so we
-    keep the rewrite line-based. The pyproject files we touch are written
-    by humans (or other tools that emit human-readable TOML); the cases
-    we need to handle are the standard ones, not pathological TOML.
+    Uses ``tomlkit`` for a round-trip edit that preserves comments and
+    formatting wherever it doesn't conflict with the edit.
     """
-    # Parse with tomllib for correctness; rewrite by string edits to
-    # preserve formatting/comments where it doesn't matter.
-    data = tomllib.loads(text)
-    project = data.get("project", {})
-    build_system = data.get("build-system", {})
+    doc = tomlkit.parse(text)
 
-    # --- [build-system].requires ---------------------------------------
-    new_text = text
-    requires = build_system.get("requires")
-    if requires:
-        new_requires = _build_requires_drop_retrofy(requires)
-        if new_requires != requires:
-            new_text = _rewrite_array_value(
-                new_text,
-                "build-system",
-                "requires",
-                new_requires,
-            )
+    build_system = doc.get("build-system")
+    if build_system is not None:
+        requires = build_system.get("requires")
+        if requires is not None:
+            new_requires = _build_requires_drop_retrofy(list(requires))
+            if new_requires != list(requires):
+                build_system["requires"] = new_requires
 
-    # --- [project].dynamic --------------------------------------------
-    dynamic = project.get("dynamic", []) or []
-    if "requires-python" in dynamic:
-        new_dynamic = [d for d in dynamic if d != "requires-python"]
-        new_text = _rewrite_array_value(
-            new_text,
-            "project",
-            "dynamic",
-            new_dynamic,
-        )
+    project = doc.get("project")
+    if project is not None:
+        dynamic = project.get("dynamic")
+        if dynamic is not None and "requires-python" in dynamic:
+            project["dynamic"] = [d for d in dynamic if d != "requires-python"]
+        project["requires-python"] = f">={floor}"
 
-    # --- [project].requires-python -------------------------------------
-    new_text = _set_requires_python(new_text, floor)
-
-    return new_text
-
-
-_TABLE_HEADER_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
-
-
-def _find_table_span(text: str, table_name: str) -> tuple[int, int] | None:
-    """Return ``(start, end)`` byte offsets of the body of ``[table_name]``
-    in ``text``, or ``None`` if the table is absent. ``start`` is just
-    after the header line; ``end`` is at the start of the next table
-    header (or EOF).
-    """
-    lines = text.splitlines(keepends=True)
-    start_line: int | None = None
-    for i, line in enumerate(lines):
-        m = _TABLE_HEADER_RE.match(line)
-        if m and m.group(1).strip() == table_name:
-            start_line = i + 1
-            break
-    if start_line is None:
-        return None
-    end_line = len(lines)
-    for j in range(start_line, len(lines)):
-        m = _TABLE_HEADER_RE.match(lines[j])
-        if m:
-            end_line = j
-            break
-    start = sum(len(line) for line in lines[:start_line])
-    end = sum(len(line) for line in lines[:end_line])
-    return start, end
-
-
-_KEY_RE_TMPL = r"^(\s*){key}\s*=\s*"
-
-
-def _rewrite_array_value(
-    text: str,
-    table: str,
-    key: str,
-    new_value: list[str],
-) -> str:
-    """Replace the value of ``table.key`` (assumed to be an inline array)
-    with ``new_value`` rendered as a single-line inline array. Leaves
-    other formatting untouched. If the key isn't found, returns text
-    unchanged.
-    """
-    span = _find_table_span(text, table)
-    if span is None:
-        return text
-    start, end = span
-    body = text[start:end]
-    pattern = re.compile(
-        _KEY_RE_TMPL.format(key=re.escape(key)) + r"(\[[^\]]*\])",
-        flags=re.MULTILINE,
-    )
-    rendered = "[" + ", ".join(f'"{v}"' for v in new_value) + "]"
-    new_body, n = pattern.subn(
-        lambda m: f"{m.group(1)}{key} = {rendered}",
-        body,
-        count=1,
-    )
-    if n == 0:
-        return text
-    return text[:start] + new_body + text[end:]
-
-
-def _set_requires_python(text: str, floor: str) -> str:
-    """Set ``[project].requires-python = ">={floor}"``. If the table
-    exists but the key doesn't, append the key inside the table; if the
-    table is missing, return text unchanged (a pyproject without
-    ``[project]`` isn't a PEP 621 project and we have nothing to lower).
-    """
-    span = _find_table_span(text, "project")
-    if span is None:
-        return text
-    start, end = span
-    body = text[start:end]
-    pattern = re.compile(
-        _KEY_RE_TMPL.format(key=re.escape("requires-python")) + r'"[^"]*"',
-        flags=re.MULTILINE,
-    )
-    new_body, n = pattern.subn(
-        lambda m: f'{m.group(1)}requires-python = ">={floor}"',
-        body,
-        count=1,
-    )
-    if n == 0:
-        # Append at the end of the table body.
-        trailing_blank = ""
-        if not body.endswith("\n"):
-            trailing_blank = "\n"
-        new_body = body + trailing_blank + f'requires-python = ">={floor}"\n'
-    return text[:start] + new_body + text[end:]
+    return tomlkit.dumps(doc)
 
 
 def lower_sdist(sdist_path: pathlib.Path) -> None:
     """``post-build-sdist`` hook.
 
-    When ``[tool.retrofy] target-python`` is set, rewrite the sdist in
-    place so it is installable on the target Python without retrofy in
-    the build environment: convert source files, inject ``_retrofy_rt/``
-    where needed, lower ``Requires-Python`` in pyproject + PKG-INFO,
-    and strip ``retrofy`` from ``[build-system].requires``.
+    Mirrors the wheel hook (``compatibility_via_rewrite``): source
+    conversion runs unconditionally, ``_retrofy_rt/`` is injected
+    wherever converted source references it, and the
+    ``Requires-Python`` / ``[build-system].requires`` rewrites are
+    gated on ``[tool.retrofy] target-python``.
 
-    ``RETROFY_DISABLE_REWRITE=1`` short-circuits to a no-op, mirroring
-    the wheel hook's bootstrap escape.
+    ``RETROFY_DISABLE_REWRITE=1`` short-circuits to a no-op for the
+    retrofy self-build bootstrap, matching the wheel hook.
     """
     if os.environ.get("RETROFY_DISABLE_REWRITE") == "1":
         _log.info("RETROFY_DISABLE_REWRITE=1 — skipping sdist rewrite")
         return
-    target_py = _read_target_python(pathlib.Path.cwd())
-    if target_py is None:
-        return
-    floor = target_py.lstrip(">=")
+    floor = _read_target_python(pathlib.Path.cwd())
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = pathlib.Path(tmpdir)
@@ -544,6 +434,8 @@ def lower_sdist(sdist_path: pathlib.Path) -> None:
             # DeprecationWarning and behaves like fully-trusted. We're
             # opening a sdist we just produced ourselves, not user-
             # supplied input, so trusted-extraction is acceptable.
+            # Tracked in pelson/retrofy#39 -- candidate for a retrofy
+            # converter that emits this fallback automatically.
             if sys.version_info >= (3, 12):
                 tar.extractall(tmp, filter="data")
             else:
@@ -556,7 +448,12 @@ def lower_sdist(sdist_path: pathlib.Path) -> None:
             if p.is_file()
         }
 
-        # Convert sources + collect lazy runtime dirs.
+        has_modifications = False
+
+        # Convert sources unconditionally -- the same modern syntax that
+        # the wheel hook lowers is unparseable on any older Python, so
+        # source lowering is universally useful even when the project
+        # has not opted into metadata lowering via ``target-python``.
         lazy_runtime_dirs: set[str] = set()
         for py in root.rglob("*.py"):
             text = py.read_text(encoding="utf-8")
@@ -567,6 +464,7 @@ def lower_sdist(sdist_path: pathlib.Path) -> None:
                     "Converted %s to compatibility syntax",
                     py.relative_to(root),
                 )
+                has_modifications = True
                 if _LAZY_RUNTIME_IMPORT_MARKER in new_text:
                     rel = posixpath.dirname(
                         str(py.relative_to(root)).replace(os.sep, "/"),
@@ -602,22 +500,28 @@ def lower_sdist(sdist_path: pathlib.Path) -> None:
                     "Injected retrofy runtime payload into %s/",
                     target_dir,
                 )
+                has_modifications = True
 
-        # Patch pyproject.toml.
-        pyproj = root / "pyproject.toml"
-        if pyproj.exists():
-            text = pyproj.read_text(encoding="utf-8")
-            new_text = _patch_pyproject_for_lowered_sdist(text, floor)
-            if new_text != text:
-                pyproj.write_text(new_text, encoding="utf-8")
+        # Metadata lowering is opt-in via ``[tool.retrofy] target-python``.
+        if floor is not None:
+            spec = f">={floor}"
+            pyproj = root / "pyproject.toml"
+            if pyproj.exists():
+                text = pyproj.read_text(encoding="utf-8")
+                new_text = _patch_pyproject_for_lowered_sdist(text, floor)
+                if new_text != text:
+                    pyproj.write_text(new_text, encoding="utf-8")
+                    has_modifications = True
+            pkg_info = root / "PKG-INFO"
+            if pkg_info.exists():
+                text = pkg_info.read_text(encoding="utf-8")
+                new_text = _lower_requires_python(text, spec)
+                if new_text != text:
+                    pkg_info.write_text(new_text, encoding="utf-8")
+                    has_modifications = True
 
-        # Patch PKG-INFO.
-        pkg_info = root / "PKG-INFO"
-        if pkg_info.exists():
-            text = pkg_info.read_text(encoding="utf-8")
-            new_text = _lower_requires_python(text, target_py)
-            if new_text != text:
-                pkg_info.write_text(new_text, encoding="utf-8")
+        if not has_modifications:
+            return
 
         # Repack.
         tmp_sdist = sdist_path.with_suffix(sdist_path.suffix + ".tmp")

--- a/retrofy/_pep517_hooks.py
+++ b/retrofy/_pep517_hooks.py
@@ -5,8 +5,11 @@ import logging
 import os
 import pathlib
 import posixpath
+import re
 import shutil
 import sys
+import tarfile
+import tempfile
 import zipfile
 
 from setuptools_ext import WheelModifier
@@ -330,3 +333,294 @@ def compatibility_via_rewrite(wheel: pathlib.Path):
                 whl.write_wheel(whl_fh)
 
     editable_copy.unlink()
+
+
+def _strip_top_level(member_name: str) -> tuple[str, str]:
+    """Return ``(top_level, relpath)`` for a tar member name.
+
+    Sdists are canonically packaged as ``name-version/...`` -- one
+    top-level directory containing everything. We don't accept anything
+    else.
+    """
+    head, _, rest = member_name.partition("/")
+    return head, rest
+
+
+def _build_requires_drop_retrofy(requires: list[str]) -> list[str]:
+    """Return ``requires`` with any entry whose PEP 508-normalised name is
+    ``retrofy`` removed. Entries that are not parseable as PEP 508
+    requirements are passed through unchanged.
+    """
+    out: list[str] = []
+    for spec in requires:
+        # Cheap parse: name is everything up to the first
+        # ``<``, ``=``, ``>``, ``!``, ``~``, ``;``, ``[``, or whitespace.
+        # Normalize per PEP 503 (lowercase, ``-``/``_``/``.`` collapsed).
+        m = re.match(r"\s*([A-Za-z0-9][A-Za-z0-9._-]*)", spec)
+        if not m:
+            out.append(spec)
+            continue
+        name = re.sub(r"[-_.]+", "-", m.group(1)).lower()
+        if name == "retrofy":
+            continue
+        out.append(spec)
+    return out
+
+
+def _patch_pyproject_for_lowered_sdist(text: str, floor: str) -> str:
+    """Patch a sdist's ``pyproject.toml`` text for the lowered sdist:
+
+    - rewrite ``[project].requires-python`` to ``>={floor}``; if
+      ``requires-python`` was in ``[project].dynamic``, drop it.
+    - drop ``retrofy`` from ``[build-system].requires``.
+
+    Implementation note: round-tripping TOML losslessly is hard, so we
+    keep the rewrite line-based. The pyproject files we touch are written
+    by humans (or other tools that emit human-readable TOML); the cases
+    we need to handle are the standard ones, not pathological TOML.
+    """
+    # Parse with tomllib for correctness; rewrite by string edits to
+    # preserve formatting/comments where it doesn't matter.
+    data = tomllib.loads(text)
+    project = data.get("project", {})
+    build_system = data.get("build-system", {})
+
+    # --- [build-system].requires ---------------------------------------
+    new_text = text
+    requires = build_system.get("requires")
+    if requires:
+        new_requires = _build_requires_drop_retrofy(requires)
+        if new_requires != requires:
+            new_text = _rewrite_array_value(
+                new_text,
+                "build-system",
+                "requires",
+                new_requires,
+            )
+
+    # --- [project].dynamic --------------------------------------------
+    dynamic = project.get("dynamic", []) or []
+    if "requires-python" in dynamic:
+        new_dynamic = [d for d in dynamic if d != "requires-python"]
+        new_text = _rewrite_array_value(
+            new_text,
+            "project",
+            "dynamic",
+            new_dynamic,
+        )
+
+    # --- [project].requires-python -------------------------------------
+    new_text = _set_requires_python(new_text, floor)
+
+    return new_text
+
+
+_TABLE_HEADER_RE = re.compile(r"^\s*\[([^\]]+)\]\s*$")
+
+
+def _find_table_span(text: str, table_name: str) -> tuple[int, int] | None:
+    """Return ``(start, end)`` byte offsets of the body of ``[table_name]``
+    in ``text``, or ``None`` if the table is absent. ``start`` is just
+    after the header line; ``end`` is at the start of the next table
+    header (or EOF).
+    """
+    lines = text.splitlines(keepends=True)
+    start_line: int | None = None
+    for i, line in enumerate(lines):
+        m = _TABLE_HEADER_RE.match(line)
+        if m and m.group(1).strip() == table_name:
+            start_line = i + 1
+            break
+    if start_line is None:
+        return None
+    end_line = len(lines)
+    for j in range(start_line, len(lines)):
+        m = _TABLE_HEADER_RE.match(lines[j])
+        if m:
+            end_line = j
+            break
+    start = sum(len(line) for line in lines[:start_line])
+    end = sum(len(line) for line in lines[:end_line])
+    return start, end
+
+
+_KEY_RE_TMPL = r"^(\s*){key}\s*=\s*"
+
+
+def _rewrite_array_value(
+    text: str,
+    table: str,
+    key: str,
+    new_value: list[str],
+) -> str:
+    """Replace the value of ``table.key`` (assumed to be an inline array)
+    with ``new_value`` rendered as a single-line inline array. Leaves
+    other formatting untouched. If the key isn't found, returns text
+    unchanged.
+    """
+    span = _find_table_span(text, table)
+    if span is None:
+        return text
+    start, end = span
+    body = text[start:end]
+    pattern = re.compile(
+        _KEY_RE_TMPL.format(key=re.escape(key)) + r"(\[[^\]]*\])",
+        flags=re.MULTILINE,
+    )
+    rendered = "[" + ", ".join(f'"{v}"' for v in new_value) + "]"
+    new_body, n = pattern.subn(
+        lambda m: f"{m.group(1)}{key} = {rendered}",
+        body,
+        count=1,
+    )
+    if n == 0:
+        return text
+    return text[:start] + new_body + text[end:]
+
+
+def _set_requires_python(text: str, floor: str) -> str:
+    """Set ``[project].requires-python = ">={floor}"``. If the table
+    exists but the key doesn't, append the key inside the table; if the
+    table is missing, return text unchanged (a pyproject without
+    ``[project]`` isn't a PEP 621 project and we have nothing to lower).
+    """
+    span = _find_table_span(text, "project")
+    if span is None:
+        return text
+    start, end = span
+    body = text[start:end]
+    pattern = re.compile(
+        _KEY_RE_TMPL.format(key=re.escape("requires-python")) + r'"[^"]*"',
+        flags=re.MULTILINE,
+    )
+    new_body, n = pattern.subn(
+        lambda m: f'{m.group(1)}requires-python = ">={floor}"',
+        body,
+        count=1,
+    )
+    if n == 0:
+        # Append at the end of the table body.
+        trailing_blank = ""
+        if not body.endswith("\n"):
+            trailing_blank = "\n"
+        new_body = body + trailing_blank + f'requires-python = ">={floor}"\n'
+    return text[:start] + new_body + text[end:]
+
+
+def lower_sdist(sdist_path: pathlib.Path) -> None:
+    """``post-build-sdist`` hook.
+
+    When ``[tool.retrofy] target-python`` is set, rewrite the sdist in
+    place so it is installable on the target Python without retrofy in
+    the build environment: convert source files, inject ``_retrofy_rt/``
+    where needed, lower ``Requires-Python`` in pyproject + PKG-INFO,
+    and strip ``retrofy`` from ``[build-system].requires``.
+
+    ``RETROFY_DISABLE_REWRITE=1`` short-circuits to a no-op, mirroring
+    the wheel hook's bootstrap escape.
+    """
+    if os.environ.get("RETROFY_DISABLE_REWRITE") == "1":
+        _log.info("RETROFY_DISABLE_REWRITE=1 — skipping sdist rewrite")
+        return
+    target_py = _read_target_python(pathlib.Path.cwd())
+    if target_py is None:
+        return
+    floor = target_py.lstrip(">=")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = pathlib.Path(tmpdir)
+        with tarfile.open(sdist_path, "r:gz") as tar:
+            members = tar.getmembers()
+            top_levels = {_strip_top_level(m.name)[0] for m in members if m.name}
+            if len(top_levels) != 1:
+                raise RuntimeError(
+                    f"sdist {sdist_path.name} does not have a single "
+                    f"top-level directory (found {sorted(top_levels)!r}); "
+                    f"retrofy's sdist lowering only supports the standard "
+                    f"name-version layout.",
+                )
+            top = next(iter(top_levels))
+            # ``filter="data"`` lands in 3.12; on 3.9-3.11 it emits a
+            # DeprecationWarning and behaves like fully-trusted. We're
+            # opening a sdist we just produced ourselves, not user-
+            # supplied input, so trusted-extraction is acceptable.
+            if sys.version_info >= (3, 12):
+                tar.extractall(tmp, filter="data")
+            else:
+                tar.extractall(tmp)  # noqa: S202  # see comment above
+
+        root = tmp / top
+        existing_entries = {
+            str(p.relative_to(root)).replace(os.sep, "/")
+            for p in root.rglob("*")
+            if p.is_file()
+        }
+
+        # Convert sources + collect lazy runtime dirs.
+        lazy_runtime_dirs: set[str] = set()
+        for py in root.rglob("*.py"):
+            text = py.read_text(encoding="utf-8")
+            new_text = convert(text)
+            if new_text != text:
+                py.write_text(new_text, encoding="utf-8")
+                _log.info(
+                    "Converted %s to compatibility syntax",
+                    py.relative_to(root),
+                )
+                if _LAZY_RUNTIME_IMPORT_MARKER in new_text:
+                    rel = posixpath.dirname(
+                        str(py.relative_to(root)).replace(os.sep, "/"),
+                    )
+                    lazy_runtime_dirs.add(rel)
+
+        # Inject _retrofy_rt/ payload where needed.
+        if lazy_runtime_dirs:
+            payload = _embedded_runtime_files()
+            for pkg_dir in sorted(lazy_runtime_dirs):
+                target_dir = f"{pkg_dir}/_retrofy_rt" if pkg_dir else "_retrofy_rt"
+                if f"{target_dir}/lazy_imports.py" in existing_entries:
+                    continue
+                clash = [
+                    e
+                    for e in existing_entries
+                    if e == target_dir
+                    or e == f"{target_dir}/"
+                    or e.startswith(f"{target_dir}/")
+                ]
+                if clash:
+                    raise _EmbeddedRuntimeCollisionError(
+                        f"package directory {pkg_dir!r} already contains a "
+                        f"`_retrofy_rt` entry ({clash[0]!r}); `_retrofy_rt` "
+                        f"is reserved as retrofy's runtime namespace inside "
+                        f"converted packages.",
+                    )
+                inject_dir = root / target_dir.replace("/", os.sep)
+                inject_dir.mkdir(parents=True, exist_ok=True)
+                for relpath, data in payload.items():
+                    (inject_dir / relpath).write_bytes(data)
+                _log.info(
+                    "Injected retrofy runtime payload into %s/",
+                    target_dir,
+                )
+
+        # Patch pyproject.toml.
+        pyproj = root / "pyproject.toml"
+        if pyproj.exists():
+            text = pyproj.read_text(encoding="utf-8")
+            new_text = _patch_pyproject_for_lowered_sdist(text, floor)
+            if new_text != text:
+                pyproj.write_text(new_text, encoding="utf-8")
+
+        # Patch PKG-INFO.
+        pkg_info = root / "PKG-INFO"
+        if pkg_info.exists():
+            text = pkg_info.read_text(encoding="utf-8")
+            new_text = _lower_requires_python(text, target_py)
+            if new_text != text:
+                pkg_info.write_text(new_text, encoding="utf-8")
+
+        # Repack.
+        tmp_sdist = sdist_path.with_suffix(sdist_path.suffix + ".tmp")
+        with tarfile.open(tmp_sdist, "w:gz") as tar:
+            tar.add(root, arcname=top, recursive=True)
+        os.replace(tmp_sdist, sdist_path)

--- a/retrofy/_pep517_hooks.py
+++ b/retrofy/_pep517_hooks.py
@@ -5,7 +5,6 @@ import logging
 import os
 import pathlib
 import posixpath
-import re
 import shutil
 import sys
 import tarfile
@@ -349,21 +348,21 @@ def _strip_top_level(member_name: str) -> tuple[str, str]:
 
 
 def _build_requires_drop_retrofy(requires: list[str]) -> list[str]:
-    """Return ``requires`` with any entry whose PEP 508-normalised name is
+    """Return ``requires`` with any entry whose PEP 503-normalised name is
     ``retrofy`` removed. Entries that are not parseable as PEP 508
     requirements are passed through unchanged.
     """
+    from packaging.requirements import InvalidRequirement, Requirement
+    from packaging.utils import canonicalize_name
+
     out: list[str] = []
     for spec in requires:
-        # Cheap parse: name is everything up to the first
-        # ``<``, ``=``, ``>``, ``!``, ``~``, ``;``, ``[``, or whitespace.
-        # Normalize per PEP 503 (lowercase, ``-``/``_``/``.`` collapsed).
-        m = re.match(r"\s*([A-Za-z0-9][A-Za-z0-9._-]*)", spec)
-        if not m:
+        try:
+            req = Requirement(spec)
+        except InvalidRequirement:
             out.append(spec)
             continue
-        name = re.sub(r"[-_.]+", "-", m.group(1)).lower()
-        if name == "retrofy":
+        if canonicalize_name(req.name) == "retrofy":
             continue
         out.append(spec)
     return out

--- a/retrofy/_pep517_hooks.py
+++ b/retrofy/_pep517_hooks.py
@@ -11,6 +11,10 @@ import tarfile
 import tempfile
 import zipfile
 
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
 from setuptools_ext import WheelModifier
 import tomlkit
 
@@ -98,9 +102,11 @@ def _read_target_python(source_root: pathlib.Path) -> str | None:
     ``source_root`` via ``[tool.retrofy] target-python``, or ``None`` if
     the project does not opt in.
 
-    Callers format the floor into a PEP 440 specifier (``">=3.9"``)
-    themselves -- the bare value matches what users write in pyproject
-    and avoids a round-trip strip at every consumer.
+    The value must be a single PEP 440 version (``"3.9"``, ``"3.9.7"``)
+    -- range specifiers like ``">=3.9"`` or ``"3.9,!=3.12.*"`` are
+    rejected. ``target-python`` names the exact floor to lower to, not a
+    specifier; any range-shaped exclusions belong in the project's own
+    ``[project].requires-python`` and are preserved by the rewrite.
     """
     pyproject = source_root / "pyproject.toml"
     if not pyproject.exists():
@@ -115,6 +121,19 @@ def _read_target_python(source_root: pathlib.Path) -> str | None:
             f"got {type(floor).__name__} {floor!r}. Quote the value in "
             f"pyproject.toml -- TOML floats like ``3.10`` lose their "
             f"trailing zero and silently lower the floor.",
+        )
+    try:
+        parsed = Version(floor)
+    except InvalidVersion:
+        parsed = None
+    if parsed is None or len(parsed.release) < 2:
+        raise ValueError(
+            f"[tool.retrofy] target-python must be a single version like "
+            f'"3.9" or "3.9.7"; got {floor!r}. Range specifiers '
+            f'(">=3.9", "3.9,!=3.12.*") and lone-major values ("3") are '
+            f"not accepted here -- put any such exclusions in "
+            f"``[project].requires-python`` instead, and retrofy will "
+            f"preserve them when lowering the floor.",
         )
     return floor
 
@@ -150,29 +169,55 @@ def _splice_retrofy_requires_dist(text: str) -> str:
     return header + f"\nRequires-Dist: retrofy=={_retrofy_version()}" + suffix
 
 
+def _rewrite_requires_python_floor(existing: str | None, floor: str) -> str:
+    """Return the ``Requires-Python`` value for the lowered artefact.
+
+    ``existing`` is the project's declared spec (from ``[project]
+    .requires-python`` or the ``Requires-Python:`` METADATA line), or
+    ``None`` / empty if unset. ``floor`` is the bare version from
+    ``[tool.retrofy] target-python``.
+
+    The new value is ``>={floor}`` combined with every clause from
+    ``existing`` that isn't a lower bound. This preserves user
+    exclusions like ``!=3.12.*`` while overwriting the ``>=`` / ``>``
+    that named the pre-retrofy source floor.
+    """
+    keep: list[str] = []
+    if existing:
+        for spec in SpecifierSet(existing):
+            if spec.operator not in (">=", ">"):
+                keep.append(str(spec))
+    keep.insert(0, f">={floor}")
+    return str(SpecifierSet(",".join(keep)))
+
+
 def _lower_requires_python(text: str, floor: str) -> str:
     """Return ``text`` with the ``Requires-Python:`` line in the METADATA
-    header replaced by ``Requires-Python: {floor}``. If no such line is
-    present in the header, one is appended to the header block.
+    header rewritten to lower the floor to ``floor`` while preserving
+    any other clauses (``!=``, ``<``, ...) from the existing value. If
+    no such line is present in the header, one is appended.
 
     Only the header block (everything before the first blank line) is
     touched -- a stray ``Requires-Python:`` mention in the long
     description body is preserved verbatim.
     """
     header, sep, body = text.partition("\n\n")
-    new_value = f"Requires-Python: {floor}"
     # PEP 566 / RFC 822 headers are case-insensitive on the field name,
     # so match permissively but emit the canonical capitalisation.
     replaced = False
     out_lines = []
     for line in header.split("\n"):
         if line.lower().startswith("requires-python:"):
-            out_lines.append(new_value)
+            existing = line.split(":", 1)[1].strip()
+            new_spec = _rewrite_requires_python_floor(existing, floor)
+            out_lines.append(f"Requires-Python: {new_spec}")
             replaced = True
         else:
             out_lines.append(line)
     if not replaced:
-        out_lines.append(new_value)
+        out_lines.append(
+            f"Requires-Python: {_rewrite_requires_python_floor(None, floor)}",
+        )
     new_header = "\n".join(out_lines)
     return new_header + (sep + body if sep else "")
 
@@ -316,16 +361,15 @@ def compatibility_via_rewrite(wheel: pathlib.Path):
 
         floor = _read_target_python(pathlib.Path.cwd())
         if floor is not None:
-            spec = f">={floor}"
             metadata_name = whl.dist_info_dirname() + "/METADATA"
             metadata_text = whl.read(metadata_name).decode("utf-8")
-            new_metadata = _lower_requires_python(metadata_text, spec)
+            new_metadata = _lower_requires_python(metadata_text, floor)
             if new_metadata != metadata_text:
                 whl.write(metadata_name, new_metadata)
                 _log.info(
-                    "Lowered Requires-Python in %s to %s",
+                    "Lowered Requires-Python floor in %s to %s",
                     metadata_name,
-                    spec,
+                    floor,
                 )
                 has_modifications = True
 
@@ -352,9 +396,6 @@ def _build_requires_drop_retrofy(requires: list[str]) -> list[str]:
     ``retrofy`` removed. Entries that are not parseable as PEP 508
     requirements are passed through unchanged.
     """
-    from packaging.requirements import InvalidRequirement, Requirement
-    from packaging.utils import canonicalize_name
-
     out: list[str] = []
     for spec in requires:
         try:
@@ -371,8 +412,10 @@ def _build_requires_drop_retrofy(requires: list[str]) -> list[str]:
 def _patch_pyproject_for_lowered_sdist(text: str, floor: str) -> str:
     """Patch a sdist's ``pyproject.toml`` for the lowered sdist:
 
-    - rewrite ``[project].requires-python`` to ``>={floor}``; if
-      ``requires-python`` was in ``[project].dynamic``, drop it.
+    - rewrite ``[project].requires-python`` so its lower bound is
+      ``>={floor}``, preserving other clauses (``!=``, ``<``, ...) from
+      the source spec; if ``requires-python`` was in
+      ``[project].dynamic``, drop it.
     - drop ``retrofy`` from ``[build-system].requires`` (PEP 503
       normalised match).
 
@@ -394,7 +437,11 @@ def _patch_pyproject_for_lowered_sdist(text: str, floor: str) -> str:
         dynamic = project.get("dynamic")
         if dynamic is not None and "requires-python" in dynamic:
             project["dynamic"] = [d for d in dynamic if d != "requires-python"]
-        project["requires-python"] = f">={floor}"
+        existing = project.get("requires-python")
+        project["requires-python"] = _rewrite_requires_python_floor(
+            str(existing) if existing else None,
+            floor,
+        )
 
     return tomlkit.dumps(doc)
 
@@ -503,7 +550,6 @@ def lower_sdist(sdist_path: pathlib.Path) -> None:
 
         # Metadata lowering is opt-in via ``[tool.retrofy] target-python``.
         if floor is not None:
-            spec = f">={floor}"
             pyproj = root / "pyproject.toml"
             if pyproj.exists():
                 text = pyproj.read_text(encoding="utf-8")
@@ -514,7 +560,7 @@ def lower_sdist(sdist_path: pathlib.Path) -> None:
             pkg_info = root / "PKG-INFO"
             if pkg_info.exists():
                 text = pkg_info.read_text(encoding="utf-8")
-                new_text = _lower_requires_python(text, spec)
+                new_text = _lower_requires_python(text, floor)
                 if new_text != text:
                     pkg_info.write_text(new_text, encoding="utf-8")
                     has_modifications = True

--- a/retrofy/_pep517_hooks.py
+++ b/retrofy/_pep517_hooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import importlib.resources
 import logging
 import os
@@ -222,17 +223,75 @@ def _lower_requires_python(text: str, floor: str) -> str:
     return new_header + (sep + body if sep else "")
 
 
+def _apply_wheel_metadata_edits(text: str) -> str:
+    """Single source of truth for the ``METADATA`` transformation on the
+    wheel install path.
+
+    Called from both ``lower_metadata_requires_python`` (the
+    ``post-prepare-metadata-for-build-wheel`` hook) and
+    ``compatibility_via_rewrite`` (the ``post-build-wheel`` hook).
+    PEP 517 requires the metadata returned by
+    ``prepare_metadata_for_build_wheel`` to match what appears in the
+    wheel ``build_wheel`` produces; routing both hooks through this
+    function is how retrofy honours that.
+
+    Any new ``METADATA`` edit for wheel installs goes here, not in the
+    hooks.
+    """
+    floor = _read_target_python(pathlib.Path.cwd())
+    if floor is not None:
+        text = _lower_requires_python(text, floor)
+    return text
+
+
+def _apply_editable_metadata_edits(text: str) -> str:
+    """Single source of truth for the ``METADATA`` transformation on the
+    editable install path.
+
+    Called from both ``inject_runtime_requirement`` (the
+    ``post-prepare-metadata-for-build-editable`` hook) and
+    ``compatibility_via_import_hook`` (the ``post-build-editable``
+    hook). PEP 660 requires the metadata returned by
+    ``prepare_metadata_for_build_editable`` to match what appears in
+    the editable wheel; routing both hooks through this function is
+    how retrofy honours that.
+
+    Any new ``METADATA`` edit for editable installs goes here, not in
+    the hooks.
+    """
+    text = _splice_retrofy_requires_dist(text)
+    floor = _read_target_python(pathlib.Path.cwd())
+    if floor is not None:
+        text = _lower_requires_python(text, floor)
+    return text
+
+
 def inject_runtime_requirement(dist_info_path: pathlib.Path) -> None:
     """``post-prepare-metadata-for-build-editable`` hook.
 
-    Editable installs of a retrofy-using project keep their original
-    source on disk and rely on retrofy's import-time rewriter, so retrofy
-    must be present at runtime. Splice ``Requires-Dist: retrofy`` into
-    the prepared ``METADATA`` so pip resolves it as a runtime dep.
+    Runs the editable-install METADATA policy (see
+    ``_apply_editable_metadata_edits``) on the prepared ``METADATA`` so
+    the frontend sees the final field values before deciding whether
+    to invoke ``build_editable``.
     """
     metadata_path = dist_info_path / "METADATA"
     text = metadata_path.read_text(encoding="utf-8")
-    new_text = _splice_retrofy_requires_dist(text)
+    new_text = _apply_editable_metadata_edits(text)
+    if new_text != text:
+        metadata_path.write_text(new_text, encoding="utf-8")
+
+
+def lower_metadata_requires_python(dist_info_path: pathlib.Path) -> None:
+    """``post-prepare-metadata-for-build-wheel`` hook.
+
+    Runs the wheel-install METADATA policy (see
+    ``_apply_wheel_metadata_edits``) on the prepared ``METADATA`` so
+    the frontend sees the final field values before deciding whether
+    to invoke ``build_wheel``.
+    """
+    metadata_path = dist_info_path / "METADATA"
+    text = metadata_path.read_text(encoding="utf-8")
+    new_text = _apply_wheel_metadata_edits(text)
     if new_text != text:
         metadata_path.write_text(new_text, encoding="utf-8")
 
@@ -267,12 +326,14 @@ def compatibility_via_import_hook(wheel: pathlib.Path):
             )
             whl.write(zipfile.ZipInfo(fn), script)
 
-        # Mirror the prepare_metadata_for_build_editable splice into the
-        # final wheel so the installed dist-info also advertises retrofy
-        # as a runtime dep.
+        # PEP 660: the METADATA in the built editable wheel must match
+        # what ``prepare_metadata_for_build_editable`` returned. Route
+        # the edit through ``_apply_editable_metadata_edits`` so this
+        # hook and the pre-flight ``inject_runtime_requirement`` share
+        # one policy definition.
         metadata_name = whl.dist_info_dirname() + "/METADATA"
         metadata_text = whl.read(metadata_name).decode("utf-8")
-        new_metadata = _splice_retrofy_requires_dist(metadata_text)
+        new_metadata = _apply_editable_metadata_edits(metadata_text)
         if new_metadata != metadata_text:
             whl.write(metadata_name, new_metadata)
 
@@ -359,19 +420,18 @@ def compatibility_via_rewrite(wheel: pathlib.Path):
                 )
                 has_modifications = True
 
-        floor = _read_target_python(pathlib.Path.cwd())
-        if floor is not None:
-            metadata_name = whl.dist_info_dirname() + "/METADATA"
-            metadata_text = whl.read(metadata_name).decode("utf-8")
-            new_metadata = _lower_requires_python(metadata_text, floor)
-            if new_metadata != metadata_text:
-                whl.write(metadata_name, new_metadata)
-                _log.info(
-                    "Lowered Requires-Python floor in %s to %s",
-                    metadata_name,
-                    floor,
-                )
-                has_modifications = True
+        # PEP 517: the METADATA in the built wheel must match what
+        # ``prepare_metadata_for_build_wheel`` returned. Route the edit
+        # through ``_apply_wheel_metadata_edits`` so this hook and the
+        # pre-flight ``lower_metadata_requires_python`` share one policy
+        # definition.
+        metadata_name = whl.dist_info_dirname() + "/METADATA"
+        metadata_text = whl.read(metadata_name).decode("utf-8")
+        new_metadata = _apply_wheel_metadata_edits(metadata_text)
+        if new_metadata != metadata_text:
+            whl.write(metadata_name, new_metadata)
+            _log.info("Applied wheel-install METADATA edits to %s", metadata_name)
+            has_modifications = True
 
         if has_modifications:
             with wheel.open("wb") as whl_fh:
@@ -568,8 +628,41 @@ def lower_sdist(sdist_path: pathlib.Path) -> None:
         if not has_modifications:
             return
 
-        # Repack.
+        # Repack. Both the tar member order and the per-entry
+        # tarinfo metadata (mtime, uid, gid, uname, gname, mode) affect
+        # the sdist byte content, and so does the gzip mtime header.
+        # Walk sorted so member order is stable across filesystems, use
+        # a tarfile filter to normalise per-entry metadata, and open
+        # the gzip stream with a fixed mtime. SOURCE_DATE_EPOCH is
+        # honoured for the mtime when set (PEP 517-compatible frontends
+        # use it to opt into reproducible builds); otherwise fall back
+        # to 0.
+        source_date_epoch = int(os.environ.get("SOURCE_DATE_EPOCH", "0"))
+
+        def _normalise(info: tarfile.TarInfo) -> tarfile.TarInfo:
+            info.mtime = source_date_epoch
+            info.uid = 0
+            info.gid = 0
+            info.uname = ""
+            info.gname = ""
+            # 0755 for dirs, 0644 for files, mirroring what setuptools
+            # emits and what pip's sdist unpack expects.
+            info.mode = 0o755 if info.isdir() else 0o644
+            return info
+
         tmp_sdist = sdist_path.with_suffix(sdist_path.suffix + ".tmp")
-        with tarfile.open(tmp_sdist, "w:gz") as tar:
-            tar.add(root, arcname=top, recursive=True)
+        with (
+            open(tmp_sdist, "wb") as raw,
+            gzip.GzipFile(
+                filename="",
+                mode="wb",
+                fileobj=raw,
+                mtime=source_date_epoch,
+            ) as gz,
+            tarfile.open(fileobj=gz, mode="w") as tar,
+        ):
+            tar.add(root, arcname=top, recursive=False, filter=_normalise)
+            for path in sorted(root.rglob("*")):
+                arc = f"{top}/{path.relative_to(root).as_posix()}"
+                tar.add(path, arcname=arc, recursive=False, filter=_normalise)
         os.replace(tmp_sdist, sdist_path)

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import io
+import os
 import pathlib
 import re
 import tarfile
@@ -20,6 +21,7 @@ from retrofy._pep517_hooks import (
     _read_target_python,
     compatibility_via_rewrite,
     inject_runtime_requirement,
+    lower_metadata_requires_python,
     lower_sdist,
 )
 
@@ -81,6 +83,66 @@ def test_inject_runtime_requirement_adds_even_if_retrofy_already_present(tmp_pat
     ]
     assert len(lines) == 2
     assert PINNED_REQUIRES in lines
+
+
+def test_lower_metadata_requires_python_rewrites_when_target_set(tmp_path, monkeypatch):
+    # Pip pre-flights Requires-Python from the prepared metadata
+    # before deciding to invoke build_wheel. When the source declares
+    # >=3.15 but target-python is 3.9, the *prepared* METADATA must
+    # already say >=3.9 or pip refuses to build on <3.15 interpreters.
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "x"
+            requires-python = ">=3.15"
+            [tool.retrofy]
+            target-python = "3.9"
+            """,
+        ),
+        encoding="utf-8",
+    )
+    dist_info = _write_metadata(
+        tmp_path,
+        """\
+        Metadata-Version: 2.1
+        Name: some-project
+        Version: 0.1.0
+        Requires-Python: >=3.15
+        """,
+    )
+    monkeypatch.chdir(tmp_path)
+    lower_metadata_requires_python(dist_info)
+    text = (dist_info / "METADATA").read_text(encoding="utf-8")
+    assert "Requires-Python: >=3.9" in text
+    assert "Requires-Python: >=3.15" not in text
+
+
+def test_lower_metadata_requires_python_no_op_when_target_unset(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [project]
+            name = "x"
+            requires-python = ">=3.9"
+            """,
+        ),
+        encoding="utf-8",
+    )
+    dist_info = _write_metadata(
+        tmp_path,
+        """\
+        Metadata-Version: 2.1
+        Name: some-project
+        Version: 0.1.0
+        Requires-Python: >=3.9
+        """,
+    )
+    monkeypatch.chdir(tmp_path)
+    before = (dist_info / "METADATA").read_text(encoding="utf-8")
+    lower_metadata_requires_python(dist_info)
+    after = (dist_info / "METADATA").read_text(encoding="utf-8")
+    assert before == after
 
 
 def test_inject_runtime_requirement_no_body(tmp_path):
@@ -530,6 +592,50 @@ def _read_sdist(sdist: pathlib.Path, name: str = "dummypkg-0.0.0") -> dict[str, 
 
 def _opt_in_pyproject(text: str) -> str:
     return textwrap.dedent(text)
+
+
+def test_lower_sdist_is_reproducible(tmp_path, monkeypatch):
+    # Running lower_sdist twice on the same input must produce the
+    # same bytes. Tar member order, per-entry mtime/uid/gid/uname/gname/mode,
+    # and the gzip mtime header all otherwise vary across runs.
+    def _one() -> bytes:
+        d = tmp_path / f"iter_{os.urandom(4).hex()}"
+        d.mkdir()
+        (d / "pyproject.toml").write_text(
+            _opt_in_pyproject(
+                """\
+                [project]
+                name = "dummypkg"
+                [tool.retrofy]
+                target-python = "3.9"
+                """,
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(d)
+        sdist = _make_minimal_sdist(
+            d,
+            {
+                "dummypkg/__init__.py": "",
+                "dummypkg/a.py": "x = 1\n",
+                "dummypkg/b.py": "y = 2\n",
+                "dummypkg/sub/__init__.py": "",
+                "dummypkg/sub/c.py": "lazy from foo import bar\n",
+                "pyproject.toml": _opt_in_pyproject(
+                    """\
+                    [project]
+                    name = "dummypkg"
+                    [tool.retrofy]
+                    target-python = "3.9"
+                    """,
+                ),
+            },
+        )
+        lower_sdist(sdist)
+        return sdist.read_bytes()
+
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", "1700000000")
+    assert _one() == _one()
 
 
 def test_lower_sdist_converts_py_files(tmp_path, monkeypatch):

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import pathlib
 import re
-import sys
 import tarfile
 import textwrap
 import zipfile
@@ -713,23 +712,18 @@ def test_lower_sdist_strip_name_matches_retrofy_distribution_name():
     ]
 
 
-def test_lower_sdist_entry_point_registered_in_pyproject():
-    """Contract: retrofy's source ``pyproject.toml`` wires
-    ``post-build-sdist`` to ``lower_sdist`` so multistage-build's hook
-    discovery picks it up after install. Parses the source pyproject
-    rather than ``importlib.metadata`` so the contract is verifiable
-    without a fresh editable reinstall.
+def test_lower_sdist_entry_point_registered():
+    """Contract: the installed retrofy distribution advertises
+    ``post-build-sdist = retrofy._pep517_hooks:lower_sdist`` in the
+    ``multistage_build`` entry-point group, so multistage-build's hook
+    discovery picks it up at build time.
     """
-    import retrofy._pep517_hooks as hooks
+    import importlib.metadata
 
-    if sys.version_info >= (3, 11):
-        import tomllib as _tomllib
-    else:
-        import tomli as _tomllib
-
-    src_pyproject = (
-        pathlib.Path(hooks.__file__).resolve().parent.parent / "pyproject.toml"
+    eps = importlib.metadata.entry_points(
+        group="multistage_build",
+        name="post-build-sdist",
     )
-    data = _tomllib.loads(src_pyproject.read_text(encoding="utf-8"))
-    entry = data["project"]["entry-points"]["multistage_build"]["post-build-sdist"]
-    assert entry == "retrofy._pep517_hooks:lower_sdist"
+    retrofy_eps = [ep for ep in eps if ep.value.startswith("retrofy.")]
+    assert len(retrofy_eps) == 1
+    assert retrofy_eps[0].value == "retrofy._pep517_hooks:lower_sdist"

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -720,10 +720,12 @@ def test_lower_sdist_entry_point_registered():
     """
     import importlib.metadata
 
-    eps = importlib.metadata.entry_points(
-        group="multistage_build",
-        name="post-build-sdist",
-    )
-    retrofy_eps = [ep for ep in eps if ep.value.startswith("retrofy.")]
+    retrofy_eps = [
+        ep
+        for ep in importlib.metadata.distribution("retrofy").entry_points
+        if ep.group == "multistage_build"
+        and ep.name == "post-build-sdist"
+        and ep.value.startswith("retrofy.")
+    ]
     assert len(retrofy_eps) == 1
     assert retrofy_eps[0].value == "retrofy._pep517_hooks:lower_sdist"

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import io
 import pathlib
 import re
@@ -7,6 +8,7 @@ import tarfile
 import textwrap
 import zipfile
 
+from packaging.specifiers import SpecifierSet
 import pytest
 
 from retrofy import __version__ as RETROFY_VERSION
@@ -154,7 +156,7 @@ def test_lower_requires_python_replaces_existing_line():
         "\n"
         "Long description.\n"
     )
-    new = _lower_requires_python(text, ">=3.9")
+    new = _lower_requires_python(text, "3.9")
     assert "Requires-Python: >=3.9\n" in new
     assert "Requires-Python: >=3.15" not in new
     assert "Requires-Dist: libcst\n" in new
@@ -170,7 +172,7 @@ def test_lower_requires_python_adds_when_missing():
         "\n"
         "Body.\n"
     )
-    new = _lower_requires_python(text, ">=3.9")
+    new = _lower_requires_python(text, "3.9")
     header, _, _ = new.partition("\n\n")
     assert "Requires-Python: >=3.9" in header
 
@@ -184,7 +186,7 @@ def test_lower_requires_python_only_touches_header_block():
         "\n"
         "See Requires-Python: >=3.15 in the docs.\n"
     )
-    new = _lower_requires_python(text, ">=3.9")
+    new = _lower_requires_python(text, "3.9")
     header, _, body = new.partition("\n\n")
     assert "Requires-Python: >=3.9" in header
     assert "Requires-Python: >=3.15" not in header
@@ -196,7 +198,7 @@ def test_lower_requires_python_matches_case_insensitively():
     # lowercase ``requires-python:`` line must still be recognised
     # and replaced (with the canonical capitalisation).
     text = "Metadata-Version: 2.1\nName: retrofy\nrequires-python: >=3.15\n\nBody.\n"
-    new = _lower_requires_python(text, ">=3.9")
+    new = _lower_requires_python(text, "3.9")
     assert "Requires-Python: >=3.9" in new
     assert "requires-python: >=3.15" not in new
     assert "Requires-Python: >=3.15" not in new
@@ -257,6 +259,92 @@ def test_read_target_python_rejects_non_string(tmp_path):
     )
     with pytest.raises(TypeError, match="must be a string"):
         _read_target_python(root)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [">=3.9", "3.9,!=3.12.*", "3.9.*", "python3.9", "3", "^3.9"],
+)
+def test_read_target_python_rejects_non_single_version(tmp_path, value):
+    # ``target-python`` names the exact floor to lower to. Any specifier-
+    # shaped value (``>=``, exclusions, wildcards, empty component) is
+    # ambiguous: retrofy sets ``>={floor}`` on the built artefact and
+    # preserves the project's own ``requires-python`` exclusions. Users
+    # who want ``!=3.12.*`` should put it in ``[project].requires-python``,
+    # not here.
+    root = _write_pyproject(
+        tmp_path,
+        f"""\
+        [project]
+        name = "x"
+        [tool.retrofy]
+        target-python = "{value}"
+        """,
+    )
+    with pytest.raises(ValueError, match="single version"):
+        _read_target_python(root)
+
+
+@pytest.mark.parametrize("value", ["3.9", "3.9.7", "3.10"])
+def test_read_target_python_accepts_bare_versions(tmp_path, value):
+    root = _write_pyproject(
+        tmp_path,
+        f"""\
+        [project]
+        name = "x"
+        [tool.retrofy]
+        target-python = "{value}"
+        """,
+    )
+    assert _read_target_python(root) == value
+
+
+def test_lower_requires_python_preserves_exclusions():
+    # A project that says "we support 3.15+ but not 3.16" must keep the
+    # ``!=3.16.*`` exclusion after retrofy lowers the floor -- otherwise
+    # a user who consciously refused to run on 3.16 gets a lowered
+    # artefact that silently claims to support it.
+    text = (
+        "Metadata-Version: 2.1\n"
+        "Name: retrofy\n"
+        "Version: 0.4.0\n"
+        "Requires-Python: >=3.15,!=3.16.*\n"
+        "\n"
+        "Body.\n"
+    )
+    new = _lower_requires_python(text, "3.9")
+    header, _, _ = new.partition("\n\n")
+    # The exact clause ordering is packaging's canonical form; assert on
+    # semantic equivalence via SpecifierSet.
+    line = next(
+        line
+        for line in header.split("\n")
+        if line.lower().startswith("requires-python:")
+    )
+    spec = SpecifierSet(line.split(":", 1)[1].strip())
+    assert set(str(s) for s in spec) == {">=3.9", "!=3.16.*"}
+
+
+def test_lower_requires_python_drops_all_lower_bounds():
+    # A source spec like ">3.14" (strict >) is still a lower bound and
+    # must be replaced, not kept alongside ours.
+    text = (
+        "Metadata-Version: 2.1\n"
+        "Name: retrofy\n"
+        "Version: 0.4.0\n"
+        "Requires-Python: >3.14,<4\n"
+        "\n"
+        "Body.\n"
+    )
+    new = _lower_requires_python(text, "3.9")
+    header, _, _ = new.partition("\n\n")
+    line = next(
+        line
+        for line in header.split("\n")
+        if line.lower().startswith("requires-python:")
+    )
+    spec = SpecifierSet(line.split(":", 1)[1].strip())
+    assert set(str(s) for s in spec) == {">=3.9", "<4"}
 
 
 def _make_minimal_wheel(tmp_path: pathlib.Path, metadata_text: str) -> pathlib.Path:
@@ -699,8 +787,6 @@ def test_lower_sdist_strip_name_matches_retrofy_distribution_name():
     distribution name (PEP 503 normalised). If retrofy is ever renamed
     on PyPI, this test catches the silent miss.
     """
-    import importlib.metadata
-
     from retrofy._pep517_hooks import _build_requires_drop_retrofy
 
     dist_name = importlib.metadata.distribution("retrofy").metadata["Name"]
@@ -718,8 +804,6 @@ def test_lower_sdist_entry_point_registered():
     ``multistage_build`` entry-point group, so multistage-build's hook
     discovery picks it up at build time.
     """
-    import importlib.metadata
-
     retrofy_eps = [
         ep
         for ep in importlib.metadata.distribution("retrofy").entry_points

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -213,7 +213,7 @@ def test_read_target_python_returns_floor_when_set(tmp_path):
         target-python = "3.9"
         """,
     )
-    assert _read_target_python(root) == ">=3.9"
+    assert _read_target_python(root) == "3.9"
 
 
 def test_read_target_python_none_when_section_missing(tmp_path):
@@ -618,19 +618,30 @@ def test_lower_sdist_patches_pkg_info(tmp_path, monkeypatch):
     assert "Requires-Python: >=3.15" not in pkg_info
 
 
-def test_lower_sdist_skipped_when_target_python_unset(tmp_path, monkeypatch):
-    (tmp_path / "pyproject.toml").write_text(
-        '[project]\nname = "dummypkg"\n',
-        encoding="utf-8",
-    )
+def test_lower_sdist_converts_source_even_without_target_python(tmp_path, monkeypatch):
+    # Without ``[tool.retrofy] target-python`` the metadata edits are
+    # skipped, but source conversion still runs -- modern syntax is
+    # unparseable on older Pythons regardless of whether the project
+    # has opted into Requires-Python lowering, so emitting unconverted
+    # source would leave a half-broken sdist behind.
+    pyproject = '[project]\nname = "dummypkg"\nrequires-python = ">=3.15"\n'
+    (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
     monkeypatch.chdir(tmp_path)
     raw_source = "lazy from foo import bar\n"
-    sdist = _make_minimal_sdist(tmp_path, {"dummypkg/x.py": raw_source})
+    sdist = _make_minimal_sdist(
+        tmp_path,
+        {"dummypkg/x.py": raw_source, "pyproject.toml": pyproject},
+    )
 
     lower_sdist(sdist)
 
     files = _read_sdist(sdist)
-    assert files["dummypkg/x.py"].decode("utf-8") == raw_source
+    # Source was converted...
+    assert files["dummypkg/x.py"].decode("utf-8") != raw_source
+    assert "__lazy_from__" in files["dummypkg/x.py"].decode("utf-8")
+    # ...but pyproject/PKG-INFO were left alone.
+    assert ">=3.15" in files["pyproject.toml"].decode("utf-8")
+    assert "Requires-Python: >=3.15" in files["PKG-INFO"].decode("utf-8")
 
 
 def test_lower_sdist_skipped_when_disable_env_set(tmp_path, monkeypatch):

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import io
 import pathlib
+import re
+import sys
+import tarfile
 import textwrap
 import zipfile
 
@@ -10,10 +14,12 @@ from retrofy import __version__ as RETROFY_VERSION
 from retrofy._pep517_hooks import (
     EditableRuntimeRequirementError,
     _assert_editable_dependencies_dynamic,
+    _EmbeddedRuntimeCollisionError,
     _lower_requires_python,
     _read_target_python,
     compatibility_via_rewrite,
     inject_runtime_requirement,
+    lower_sdist,
 )
 
 PINNED_REQUIRES = f"Requires-Dist: retrofy=={RETROFY_VERSION}"
@@ -382,3 +388,337 @@ def test_compatibility_via_rewrite_skipped_when_disable_env_set(
         md = z.read("dummypkg-0.0.0.dist-info/METADATA").decode("utf-8")
     assert py == raw_source  # not converted
     assert "Requires-Python: >=3.15" in md  # METADATA not lowered
+
+
+# ---------------------------------------------------------------------------
+# lower_sdist
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_sdist(
+    tmp_path: pathlib.Path,
+    files: dict[str, str | bytes],
+    *,
+    name: str = "dummypkg-0.0.0",
+) -> pathlib.Path:
+    """Build a ``{name}.tar.gz`` at ``tmp_path`` whose top-level directory
+    is ``{name}/`` and whose contents are ``files`` (mapping of
+    ``relative/path`` -> text or bytes).
+
+    PKG-INFO is auto-supplied if not in ``files``.
+    """
+    files = dict(files)
+    files.setdefault(
+        "PKG-INFO",
+        "Metadata-Version: 2.1\n"
+        "Name: dummypkg\n"
+        "Version: 0.0.0\n"
+        "Requires-Python: >=3.15\n",
+    )
+    sdist = tmp_path / f"{name}.tar.gz"
+    with tarfile.open(sdist, "w:gz") as tar:
+        for relpath, content in files.items():
+            data = content.encode("utf-8") if isinstance(content, str) else content
+            info = tarfile.TarInfo(f"{name}/{relpath}")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return sdist
+
+
+def _read_sdist(sdist: pathlib.Path, name: str = "dummypkg-0.0.0") -> dict[str, bytes]:
+    """Read every regular file in the sdist into a dict keyed by the
+    relative path under the top-level ``{name}/`` directory."""
+    out: dict[str, bytes] = {}
+    with tarfile.open(sdist, "r:gz") as tar:
+        for member in tar.getmembers():
+            if not member.isfile():
+                continue
+            prefix = f"{name}/"
+            assert member.name.startswith(prefix), member.name
+            fh = tar.extractfile(member)
+            assert fh is not None  # isfile() above guarantees this
+            out[member.name[len(prefix) :]] = fh.read()
+    return out
+
+
+def _opt_in_pyproject(text: str) -> str:
+    return textwrap.dedent(text)
+
+
+def test_lower_sdist_converts_py_files(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        _opt_in_pyproject(
+            """\
+            [project]
+            name = "dummypkg"
+            [tool.retrofy]
+            target-python = "3.9"
+            """,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    sdist = _make_minimal_sdist(
+        tmp_path,
+        {
+            "dummypkg/__init__.py": "",
+            "dummypkg/x.py": "lazy from foo import bar\n",
+        },
+    )
+
+    lower_sdist(sdist)
+
+    files = _read_sdist(sdist)
+    assert "lazy from foo import bar" not in files["dummypkg/x.py"].decode("utf-8")
+    assert "__lazy_from__" in files["dummypkg/x.py"].decode("utf-8")
+
+
+def test_lower_sdist_injects_runtime_payload(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        _opt_in_pyproject(
+            """\
+            [project]
+            name = "dummypkg"
+            [tool.retrofy]
+            target-python = "3.9"
+            """,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    sdist = _make_minimal_sdist(
+        tmp_path,
+        {
+            "dummypkg/__init__.py": "",
+            "dummypkg/x.py": "lazy from foo import bar\n",
+        },
+    )
+
+    lower_sdist(sdist)
+
+    files = _read_sdist(sdist)
+    assert "dummypkg/_retrofy_rt/lazy_imports.py" in files
+    assert b"def lazy_from" in files["dummypkg/_retrofy_rt/lazy_imports.py"]
+
+
+def test_lower_sdist_patches_pyproject_requires_python(tmp_path, monkeypatch):
+    pyproject = _opt_in_pyproject(
+        """\
+        [build-system]
+        requires = ["multistage-build>=0.2", "setuptools", "retrofy>=0.3"]
+        build-backend = "multistage_build:backend"
+
+        [project]
+        name = "dummypkg"
+        version = "0.1"
+        requires-python = ">=3.15"
+
+        [tool.retrofy]
+        target-python = "3.9"
+        """,
+    )
+    (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sdist = _make_minimal_sdist(tmp_path, {"pyproject.toml": pyproject})
+
+    lower_sdist(sdist)
+
+    new = _read_sdist(sdist)["pyproject.toml"].decode("utf-8")
+    assert 'requires-python = ">=3.9"' in new
+    assert ">=3.15" not in new
+
+
+def test_lower_sdist_patches_pyproject_dynamic_requires_python(tmp_path, monkeypatch):
+    pyproject = _opt_in_pyproject(
+        """\
+        [build-system]
+        requires = ["multistage-build>=0.2", "setuptools", "retrofy>=0.3"]
+        build-backend = "multistage_build:backend"
+
+        [project]
+        name = "dummypkg"
+        version = "0.1"
+        dynamic = ["requires-python", "dependencies"]
+
+        [tool.retrofy]
+        target-python = "3.9"
+        """,
+    )
+    (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sdist = _make_minimal_sdist(tmp_path, {"pyproject.toml": pyproject})
+
+    lower_sdist(sdist)
+
+    new = _read_sdist(sdist)["pyproject.toml"].decode("utf-8")
+    assert 'requires-python = ">=3.9"' in new
+    # requires-python is gone from dynamic; dependencies is still there.
+    # Match the rendered inline-array line we emit.
+    assert 'dynamic = ["dependencies"]' in new
+    assert '"requires-python"' not in new
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "retrofy",
+        "retrofy>=0.3",
+        "retrofy[extra]",
+        "retrofy ; python_version < '3.13'",
+        "RetroFy",  # PEP 503 normalisation
+        "retro_fy",  # PEP 503 normalisation (underscore -> hyphen)
+    ],
+)
+def test_lower_sdist_strips_retrofy_from_build_requires(spec, tmp_path, monkeypatch):
+    pyproject = (
+        "[build-system]\n"
+        f'requires = ["multistage-build>=0.2", "setuptools", "{spec}"]\n'
+        'build-backend = "multistage_build:backend"\n'
+        "\n"
+        "[project]\n"
+        'name = "dummypkg"\n'
+        'version = "0.1"\n'
+        "\n"
+        "[tool.retrofy]\n"
+        'target-python = "3.9"\n'
+    )
+    (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    sdist = _make_minimal_sdist(tmp_path, {"pyproject.toml": pyproject})
+
+    lower_sdist(sdist)
+
+    new = _read_sdist(sdist)["pyproject.toml"].decode("utf-8")
+    requires_line = next(
+        line for line in new.splitlines() if line.strip().startswith("requires =")
+    )
+    assert "retrofy" not in requires_line.lower().replace("retro_fy", "")
+    assert "multistage-build" in requires_line
+
+
+def test_lower_sdist_patches_pkg_info(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        _opt_in_pyproject(
+            """\
+            [project]
+            name = "dummypkg"
+            [tool.retrofy]
+            target-python = "3.9"
+            """,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    sdist = _make_minimal_sdist(tmp_path, {})
+
+    lower_sdist(sdist)
+
+    pkg_info = _read_sdist(sdist)["PKG-INFO"].decode("utf-8")
+    assert "Requires-Python: >=3.9" in pkg_info
+    assert "Requires-Python: >=3.15" not in pkg_info
+
+
+def test_lower_sdist_skipped_when_target_python_unset(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "dummypkg"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    raw_source = "lazy from foo import bar\n"
+    sdist = _make_minimal_sdist(tmp_path, {"dummypkg/x.py": raw_source})
+
+    lower_sdist(sdist)
+
+    files = _read_sdist(sdist)
+    assert files["dummypkg/x.py"].decode("utf-8") == raw_source
+
+
+def test_lower_sdist_skipped_when_disable_env_set(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        _opt_in_pyproject(
+            """\
+            [project]
+            name = "dummypkg"
+            [tool.retrofy]
+            target-python = "3.9"
+            """,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RETROFY_DISABLE_REWRITE", "1")
+    raw_source = "lazy from foo import bar\n"
+    sdist = _make_minimal_sdist(tmp_path, {"dummypkg/x.py": raw_source})
+
+    lower_sdist(sdist)
+
+    files = _read_sdist(sdist)
+    assert files["dummypkg/x.py"].decode("utf-8") == raw_source
+    assert "Requires-Python: >=3.15" in files["PKG-INFO"].decode("utf-8")
+
+
+def test_lower_sdist_collision_on_existing_retrofy_rt(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text(
+        _opt_in_pyproject(
+            """\
+            [project]
+            name = "dummypkg"
+            [tool.retrofy]
+            target-python = "3.9"
+            """,
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    sdist = _make_minimal_sdist(
+        tmp_path,
+        {
+            "dummypkg/__init__.py": "",
+            "dummypkg/x.py": "lazy from foo import bar\n",
+            "dummypkg/_retrofy_rt/preexisting.py": "# user-owned\n",
+        },
+    )
+
+    with pytest.raises(_EmbeddedRuntimeCollisionError):
+        lower_sdist(sdist)
+
+
+def test_lower_sdist_strip_name_matches_retrofy_distribution_name():
+    """Contract: the name ``lower_sdist`` looks for in
+    ``[build-system].requires`` must match retrofy's installed
+    distribution name (PEP 503 normalised). If retrofy is ever renamed
+    on PyPI, this test catches the silent miss.
+    """
+    import importlib.metadata
+
+    from retrofy._pep517_hooks import _build_requires_drop_retrofy
+
+    dist_name = importlib.metadata.distribution("retrofy").metadata["Name"]
+    normalized = re.sub(r"[-_.]+", "-", dist_name).lower()
+    assert normalized == "retrofy"
+    # And a sanity round-trip: dropping the live dist name works.
+    assert _build_requires_drop_retrofy([dist_name, "multistage-build"]) == [
+        "multistage-build",
+    ]
+
+
+def test_lower_sdist_entry_point_registered_in_pyproject():
+    """Contract: retrofy's source ``pyproject.toml`` wires
+    ``post-build-sdist`` to ``lower_sdist`` so multistage-build's hook
+    discovery picks it up after install. Parses the source pyproject
+    rather than ``importlib.metadata`` so the contract is verifiable
+    without a fresh editable reinstall.
+    """
+    import retrofy._pep517_hooks as hooks
+
+    if sys.version_info >= (3, 11):
+        import tomllib as _tomllib
+    else:
+        import tomli as _tomllib
+
+    src_pyproject = (
+        pathlib.Path(hooks.__file__).resolve().parent.parent / "pyproject.toml"
+    )
+    data = _tomllib.loads(src_pyproject.read_text(encoding="utf-8"))
+    entry = data["project"]["entry-points"]["multistage_build"]["post-build-sdist"]
+    assert entry == "retrofy._pep517_hooks:lower_sdist"

--- a/retrofy/tests/test_pep517_hooks.py
+++ b/retrofy/tests/test_pep517_hooks.py
@@ -565,8 +565,8 @@ def test_lower_sdist_patches_pyproject_dynamic_requires_python(tmp_path, monkeyp
         "retrofy>=0.3",
         "retrofy[extra]",
         "retrofy ; python_version < '3.13'",
-        "RetroFy",  # PEP 503 normalisation
-        "retro_fy",  # PEP 503 normalisation (underscore -> hyphen)
+        "RetroFy",  # PEP 503 case-insensitivity
+        "RETROFY",  # PEP 503 case-insensitivity
     ],
 )
 def test_lower_sdist_strips_retrofy_from_build_requires(spec, tmp_path, monkeypatch):
@@ -592,7 +592,7 @@ def test_lower_sdist_strips_retrofy_from_build_requires(spec, tmp_path, monkeypa
     requires_line = next(
         line for line in new.splitlines() if line.strip().startswith("requires =")
     )
-    assert "retrofy" not in requires_line.lower().replace("retro_fy", "")
+    assert "retrofy" not in requires_line.lower()
     assert "multistage-build" in requires_line
 
 


### PR DESCRIPTION
New `retrofy._pep517_hooks:lower_sdist` registered as multistage-build `post-build-sdist`. Triggered by the same `[tool.retrofy] target-python` opt-in that drives wheel lowering. Honours `RETROFY_DISABLE_REWRITE=1`.

For projects that opt in, the produced sdist installs cleanly on the target Python without retrofy in the build environment:

* every `.py` is run through `convert()`
* `_retrofy_rt/` runtime payload is dropped into packages whose converted source needs it (same collision check as the wheel hook)
* `pyproject.toml` is patched in place: `requires-python` set to the lowered floor (dropped from `dynamic` if present), and `retrofy` is removed from `[build-system].requires` (PEP 508 + PEP 503 normalised match, so `retrofy>=0.3`, `retrofy[extra]`, `RetroFy`, etc. all hit)
* `PKG-INFO`'s `Requires-Python` is rewritten via the existing helper

`[tool.multistage-build]` is intentionally left untouched so any user- supplied hooks survive; only retrofy is dropped from the build env.

Bumps the pre-commit mypy mirror from v1.4.1 to v1.18.2 so its bundled typeshed knows about `tarfile.TarFile.extractall(filter=...)` (added in Python 3.12 / PEP 706).

`example-project` opts in to demonstrate the end-to-end flow. End-to-end tested locally: sdist built on 3.15, installed in a clean 3.9 venv with no retrofy preinstalled, example_project tests pass (10 passed, 1 xfailed).

Closes #33.