### PR TITLE
Publish dev retrofy simple index to GitHub Pages

### DIFF
--- a/.github/workflows/publish-dev-index.yml
+++ b/.github/workflows/publish-dev-index.yml
@@ -1,0 +1,64 @@
+name: publish-dev-index
+
+# Publish a PEP 503 simple index of the current main-branch dev retrofy
+# to GitHub Pages so downstream projects can install bleeding-edge
+# retrofy without waiting for a PyPI release:
+#
+#   pip install --extra-index-url \
+#     https://pelson.github.io/retrofy/simple/ retrofy
+#
+# The index is rebuilt from scratch on every successful push to main —
+# no history is kept.
+
+on:
+  workflow_run:
+    workflows: ["python-test"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Download retrofy dev dist from the triggering python-test run
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist-staging/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate PEP 503 simple index
+        run: |
+          uvx simple-repository-generator dist-staging/ \
+            --output public/ --copy --force
+          ls -R public/ | head -50
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
On every successful python-test run on main, regenerate a PEP 503 simple index from the built retrofy wheel + sdist via ``simple-repository-generator`` and deploy to GitHub Pages. Downstream projects can then install bleeding-edge retrofy with e.g.

``
  pip install --extra-index-url \
    https://pelson.github.io/retrofy/simple/ retrofy
``
