### PR TITLE
lazy import type checking fix follow-up: recurse into function bodies, try/except handlers; use plain typing when unshadowed

### DIFF
--- a/retrofy/_transformations/lazy_imports.py
+++ b/retrofy/_transformations/lazy_imports.py
@@ -827,6 +827,12 @@ def _duplicate_annotated_constructs(
 
     def _process_stmt(stmt):
         if isinstance(stmt, cst.FunctionDef):
+            # Recurse into the body first: in-function ``AnnAssign``
+            # statements (``x: Foo`` without a value) also need the
+            # TYPE_CHECKING/else pair even when the enclosing def's
+            # signature has no wrapped annotations.
+            new_body = _process_block(stmt.body)
+            stmt = stmt.with_changes(body=new_body)
             if _def_has_wrapped_annotation(stmt, reify_name):
                 # Take the def's leading blank lines and put them on
                 # the new ``if`` — otherwise they'd sit inside both
@@ -861,6 +867,10 @@ def _duplicate_annotated_constructs(
         if isinstance(stmt, cst.ClassDef):
             new_body = _process_block(stmt.body)
             return stmt.with_changes(body=new_body)
+        if isinstance(stmt, (cst.If, cst.For, cst.While, cst.With, cst.Try)):
+            # Compound statements that carry an ``IndentedBlock`` body
+            # can also nest annotation-carrying constructs. Recurse.
+            return _recurse_compound(stmt)
         return stmt
 
     def _process_block(block):
@@ -868,6 +878,38 @@ def _duplicate_annotated_constructs(
             new_stmts = tuple(_process_stmt(s) for s in block.body)
             return block.with_changes(body=new_stmts)
         return block
+
+    def _recurse_compound(stmt):
+        # Walk every body-carrying attribute on the compound stmt so
+        # nested constructs (AnnAssigns inside try/except/finally,
+        # etc.) go through phase 2b too.
+        changes = {}
+        for attr in ("body", "orelse", "finalbody"):
+            if not hasattr(stmt, attr):
+                continue
+            child = getattr(stmt, attr)
+            if isinstance(child, cst.IndentedBlock):
+                changes[attr] = _process_block(child)
+            elif isinstance(child, (cst.Else, cst.Finally)) and isinstance(
+                child.body,
+                cst.IndentedBlock,
+            ):
+                changes[attr] = child.with_changes(
+                    body=_process_block(child.body),
+                )
+        # ``Try`` also carries per-handler bodies in ``handlers``.
+        if isinstance(stmt, cst.Try) and stmt.handlers:
+            new_handlers = tuple(
+                h.with_changes(body=_process_block(h.body))
+                if isinstance(h.body, cst.IndentedBlock)
+                else h
+                for h in stmt.handlers
+            )
+            if any(nh is not oh for nh, oh in zip(new_handlers, stmt.handlers)):
+                changes["handlers"] = new_handlers
+        if not changes:
+            return stmt
+        return stmt.with_changes(**changes)
 
     new_body = tuple(_process_stmt(s) for s in module.body)
     return module.with_changes(body=new_body)
@@ -953,16 +995,18 @@ def _build_typing_import(alias: str | None) -> cst.SimpleStatementLine:
     )
 
 
-def _typing_safely_bound(module: cst.Module) -> bool:
-    """Return True iff ``typing`` at module scope is bound exclusively
-    by an unaliased ``import typing``.
+def _typing_is_shadowed(module: cst.Module) -> bool:
+    """Return True iff ``typing`` at module scope is bound to
+    something *other* than the stdlib module.
 
-    That's the one case where we can rewrite phase-1's mangled
-    placeholder back to the plain ``typing`` name without risk.
-    Anything else — no binding, an aliased import, a ``from`` import,
-    a rebinding assignment, a ``for typing in ...`` at module top,
-    etc. — means the user's ``typing`` isn't reliably the stdlib
-    module and we have to inject a mangled alias instead.
+    A ``typing`` binding is fine when every assignment to it comes
+    from an unaliased ``import typing`` (any number of those is OK —
+    they all bind to the same stdlib module). Anything else — an
+    aliased import (``import typing as t``), a ``from`` import
+    (``from x import typing``), a plain assignment (``typing = 5``),
+    a ``for typing in ...`` at module scope, etc. — means the name
+    ``typing`` is not reliably the stdlib module at the emit site,
+    and we have to fall back to a mangled alias.
     """
     wrapper = cst.metadata.MetadataWrapper(module)
     scopes = wrapper.resolve(cst.metadata.ScopeProvider)
@@ -974,25 +1018,42 @@ def _typing_safely_bound(module: cst.Module) -> bool:
     if global_scope is None:
         return False
 
-    assignments = list(global_scope["typing"])
-    if len(assignments) != 1:
-        return False
-    (only,) = assignments
-    if not isinstance(only, cst.metadata.ImportAssignment):
-        return False
-    # ``ImportAssignment.node`` is the outer ``Import`` / ``ImportFrom``
-    # statement rather than the specific alias — we have to walk its
-    # aliases and confirm one binds the bare name ``typing``.
-    node = only.node
-    if not isinstance(node, cst.Import):
-        return False
-    for alias in node.names:
-        if (
-            isinstance(alias.name, cst.Name)
-            and alias.name.value == "typing"
-            and alias.asname is None
+    for assignment in global_scope["typing"]:
+        if not isinstance(assignment, cst.metadata.ImportAssignment):
+            return True
+        # ``ImportAssignment.node`` is the outer ``Import`` /
+        # ``ImportFrom`` statement — walk its aliases to check if one
+        # binds the bare name ``typing`` unaliased.
+        node = assignment.node
+        if not isinstance(node, cst.Import):
+            return True
+        if not any(
+            isinstance(a.name, cst.Name)
+            and a.name.value == "typing"
+            and a.asname is None
+            for a in node.names
         ):
             return True
+    return False
+
+
+def _module_has_import_typing(module: cst.Module) -> bool:
+    """Return True if the module has a top-level, unaliased
+    ``import typing`` — so we don't need to inject a duplicate.
+    """
+    for stmt in module.body:
+        if not isinstance(stmt, cst.SimpleStatementLine):
+            continue
+        for inner in stmt.body:
+            if not isinstance(inner, cst.Import):
+                continue
+            for alias in inner.names:
+                if (
+                    isinstance(alias.name, cst.Name)
+                    and alias.name.value == "typing"
+                    and alias.asname is None
+                ):
+                    return True
     return False
 
 
@@ -1051,17 +1112,30 @@ def _inject_runtime_import(
         return source
 
     module = cst.parse_module(source)
-    if _typing_safely_bound(module):
-        # ``typing`` is already the stdlib module and never shadowed;
-        # collapse our placeholder back to the plain name and skip the
-        # injection.
+
+    # Decide whether emitted blocks reference plain ``typing`` or the
+    # mangled ``__lazy_typing__`` alias. Plain works whenever
+    # ``typing`` at module scope isn't bound to something other than
+    # the stdlib module; the mangled alias is only needed when the
+    # user's source actively shadows the name.
+    #
+    # ``ImportManager`` in ``import_utils`` is the closest existing
+    # helper but doesn't dedupe or handle aliases — the deeper
+    # refactor is tracked at #51. For now, ``typing`` gets injected
+    # in the plain case only if not already present, and the aliased
+    # case emits its own ``import typing as <mangled>``.
+    if _typing_is_shadowed(module):
+        typing_import: cst.SimpleStatementLine | None = _build_typing_import(
+            helpers.typing_module,
+        )
+    else:
         module = cst.ensure_type(
             module.visit(_RewritePlaceholderToTyping(helpers.typing_module)),
             cst.Module,
         )
-        inject_typing = False
-    else:
-        inject_typing = True
+        typing_import = (
+            None if _module_has_import_typing(module) else _build_typing_import(None)
+        )
 
     body = list(module.body)
     insert_at = 0
@@ -1071,8 +1145,8 @@ def _inject_runtime_import(
         insert_at += 1
 
     injected: list[cst.SimpleStatementLine] = []
-    if inject_typing:
-        injected.append(_build_typing_import(helpers.typing_module))
+    if typing_import is not None:
+        injected.append(typing_import)
     injected.append(_build_runtime_import(helpers, used))
 
     if insert_at < len(body):

--- a/retrofy/tests/test_lazy_imports.py
+++ b/retrofy/tests/test_lazy_imports.py
@@ -50,14 +50,28 @@ def _norm(s: str) -> str:
 
 def _build_preamble(body: str) -> str:
     """Reconstruct the injected preamble for a body containing the
-    given helper aliases. Adds ``import typing as __lazy_typing__``
-    only when the body references the placeholder — the alias is
-    collapsed to plain ``typing`` when the source already has a safe
-    top-level ``import typing``.
+    given helper aliases.
+
+    * If the body has any ``__lazy_typing__`` reference, the source
+      was in the ``typing``-is-shadowed case and phase 3 injects
+      ``import typing as __lazy_typing__``.
+    * Else, if the body uses ``typing.TYPE_CHECKING``, phase 3 injects
+      a plain ``import typing`` (unless the fixture already provides
+      it — the test author handles that by inlining the ``import
+      typing`` line rather than the placeholder).
+    * Only the ``_retrofy_rt`` helpers whose mangled names appear in
+      the body are declared in the ``from ._retrofy_rt.lazy_imports
+      import ...`` line.
     """
     lines = []
+    body_lines = [line.strip() for line in body.splitlines()]
     if "__lazy_typing__" in body:
         lines.append("import typing as __lazy_typing__")
+    elif "typing.TYPE_CHECKING" in body and "import typing" not in body_lines:
+        # Only inject when the fixture doesn't already provide it;
+        # otherwise the retrofy runtime import is the only preamble
+        # line to inject and phase 3 skips the ``import typing`` dup.
+        lines.append("import typing")
     aliases = [
         f"{role} as {_BASE_HELPERS[role]}"
         for role in _BASE_HELPERS
@@ -70,7 +84,7 @@ def _build_preamble(body: str) -> str:
 def _block(
     tc_lines: list[str],
     rt_lines: list[str],
-    tc_name: str = "__lazy_typing__",
+    tc_name: str = "typing",
 ) -> str:
     """Format a per-statement ``if <tc_name>.TYPE_CHECKING: ...\\n
     else: ...`` block matching the transformer's emit shape.
@@ -89,6 +103,12 @@ def _expected(*sections: str) -> str:
 
 
 def _assert_transform(src: str, expected: str) -> None:
+    # Dedent the expected template first so plain-string f-string
+    # tests (which write the expected shape as literal indented code)
+    # work alongside ``_expected(*sections)`` tests. After dedent, the
+    # ``_RUNTIME_IMPORT`` marker sits at column 0 and gets replaced
+    # by the multi-line preamble string at column 0 too.
+    expected = _norm(expected)
     if _RUNTIME_IMPORT in expected:
         rest = expected.replace(_RUNTIME_IMPORT, "")
         expected = expected.replace(_RUNTIME_IMPORT, _build_preamble(rest))
@@ -665,6 +685,7 @@ def test_typing_alias_kept_when_typing_shadowed_by_for_loop() -> None:
             _block(
                 ["from mod import X"],
                 ["X = __lazy_from__('mod', 'X', 'X')"],
+                tc_name="__lazy_typing__",
             ),
             "",
             "x = __lazy_reify__(X)",
@@ -672,10 +693,12 @@ def test_typing_alias_kept_when_typing_shadowed_by_for_loop() -> None:
     )
 
 
-def test_typing_alias_kept_when_typing_import_is_aliased() -> None:
-    # ``import typing as t`` doesn't bind the bare name ``typing``, so
-    # phase 3 has to inject its own ``import typing as __lazy_typing__``
-    # rather than trusting the user's aliased import.
+def test_plain_typing_injected_when_aliased_import_present() -> None:
+    # ``import typing as t`` doesn't bind the bare name ``typing``,
+    # but it also doesn't shadow it — the name is simply unbound. So
+    # phase 3 injects a fresh ``import typing`` and emits plain
+    # ``typing.TYPE_CHECKING`` blocks. The user's ``import typing as
+    # t`` is left alone (they still use ``t`` for their own purposes).
     _assert_transform(
         """
         import typing as t
@@ -698,9 +721,10 @@ def test_typing_alias_kept_when_typing_import_is_aliased() -> None:
     )
 
 
-def test_typing_alias_kept_when_only_from_typing_import() -> None:
-    # ``from typing import X`` does not bind the name ``typing``; the
-    # libcst pass must inject its own alias.
+def test_plain_typing_injected_when_only_from_typing_import() -> None:
+    # ``from typing import Optional`` binds ``Optional``, not
+    # ``typing``. Phase 3 still injects a plain ``import typing``
+    # and emits ``typing.TYPE_CHECKING`` — no shadowing risk.
     _assert_transform(
         """
         from typing import Optional
@@ -724,12 +748,18 @@ def test_typing_alias_kept_when_only_from_typing_import() -> None:
 
 
 def test_typing_alias_suffix_bumps_on_collision() -> None:
-    # If the user's source already binds ``__lazy_typing__``, the
-    # ``typing`` alias must bump to ``__lazy_typing_2__`` etc. so we
-    # can't clobber the user's binding.
+    # The mangled ``__lazy_typing__`` alias only appears in the emit
+    # when ``typing`` is shadowed. If the user's source *also* binds
+    # the un-suffixed placeholder name, the alias must bump to
+    # ``__lazy_typing_2__`` so we can't clobber the user's binding.
     src = _norm(
         """
-        __lazy_typing__ = 'user-bound'
+        import typing
+
+        for typing in []:  # actively shadow ``typing``
+            pass
+
+        __lazy_typing__ = 'user-bound'  # collide with the placeholder
 
         lazy from mod import X
 
@@ -746,6 +776,118 @@ def test_typing_alias_suffix_bumps_on_collision() -> None:
     assert "if __lazy_typing__.TYPE_CHECKING:" not in out
     # User's literal binding is preserved verbatim.
     assert "__lazy_typing__ = 'user-bound'" in out
+
+
+def test_in_function_bare_annassign_is_type_checking_paired() -> None:
+    # Follow-up to phase 2b: a bare ``AnnAssign`` inside a function
+    # body (``x: Foo`` with no value — commonly used to forward-
+    # declare a variable's type before a conditional assign) also
+    # needs the TYPE_CHECKING/else pair. Otherwise phase 2's
+    # ``__lazy_reify__(Foo)`` wrap ends up in the annotation slot
+    # and mypy rejects it with ``[valid-type]``.
+    _assert_transform(
+        """
+        lazy from some_pkg import Foo
+
+        def f():
+            x: Foo
+            del x
+        """,
+        f"""
+        {_RUNTIME_IMPORT}
+        if typing.TYPE_CHECKING:
+            from some_pkg import Foo
+        else:
+            Foo = __lazy_from__('some_pkg', 'Foo', 'Foo')
+
+        def f():
+            if typing.TYPE_CHECKING:
+                x: Foo
+            else:
+                x: __lazy_reify__(Foo)
+            del x
+        """,
+    )
+
+
+def test_in_method_bare_annassign_is_type_checking_paired() -> None:
+    # Same shape but nested one level deeper — inside a class body's
+    # method body. Guards phase-2b recursion through both ClassDef
+    # and FunctionDef.
+    _assert_transform(
+        """
+        lazy from some_pkg import Foo
+
+        class C:
+            def m(self):
+                z: Foo
+                del z
+        """,
+        f"""
+        {_RUNTIME_IMPORT}
+        if typing.TYPE_CHECKING:
+            from some_pkg import Foo
+        else:
+            Foo = __lazy_from__('some_pkg', 'Foo', 'Foo')
+
+        class C:
+            def m(self):
+                if typing.TYPE_CHECKING:
+                    z: Foo
+                else:
+                    z: __lazy_reify__(Foo)
+                del z
+        """,
+    )
+
+
+def test_annassign_inside_try_except_finally_is_paired() -> None:
+    # Compound statements that carry ``IndentedBlock`` bodies (``if``,
+    # ``for``, ``while``, ``with``, ``try``) also nest annotation-
+    # carrying constructs. Phase 2b's ``_recurse_compound`` walks the
+    # body / orelse / finalbody / ExceptHandler bodies.
+    _assert_transform(
+        """
+        lazy from some_pkg import Foo
+
+        try:
+            a: Foo
+        except Exception:
+            b: Foo
+        else:
+            c: Foo
+        finally:
+            d: Foo
+        """,
+        f"""
+        {_RUNTIME_IMPORT}
+        if typing.TYPE_CHECKING:
+            from some_pkg import Foo
+        else:
+            Foo = __lazy_from__('some_pkg', 'Foo', 'Foo')
+
+        try:
+            if typing.TYPE_CHECKING:
+                a: Foo
+            else:
+                a: __lazy_reify__(Foo)
+        except Exception:
+            if typing.TYPE_CHECKING:
+                b: Foo
+            else:
+                b: __lazy_reify__(Foo)
+        else:
+            if typing.TYPE_CHECKING:
+                c: Foo
+            else:
+                c: __lazy_reify__(Foo)
+        finally:
+            if typing.TYPE_CHECKING:
+                d: Foo
+            else:
+                d: __lazy_reify__(Foo)
+        """,
+    )
 
 
 def test_multiple_lazy_statements() -> None:


### PR DESCRIPTION
Two follow-ups on top of the phase 2b TYPE_CHECKING/else pass:

**In-function ``AnnAssign`` (issue #45 review comment):** a bare ``x: Foo`` inside a function body / method body / try/except/finally etc. was getting the phase-2 ``__lazy_reify__(Foo)`` wrap on its annotation, but phase 2b only walked module and class bodies — so the wrap ended up unpaired and mypy rejected the annotation with ``[valid-type]``. Phase 2b now recurses into ``FunctionDef`` bodies regardless of whether the signature has wrapped annotations, and ``_recurse_compound`` walks ``if`` / ``for`` / ``while`` / ``with`` / ``try`` bodies (including ``ExceptHandler`` bodies and the ``Finally`` body).

**Plain ``typing`` when not shadowed:** the phase 3 emit was always injecting the mangled ``import typing as __lazy_typing__`` alias when the source lacked an unaliased ``import typing``, even though the ``typing`` name wasn't actually shadowed. Under the refined logic, ``typing`` is treated as safe unless the module scope binds it to something other than the stdlib module (aliased import, ``from typing import ...``, plain assignment, ``for typing in ...``, etc.). In the not-shadowed case, phase 3 injects a plain ``import typing`` (unless the source already provides one) and the emitted blocks use the natural ``typing.TYPE_CHECKING`` reference. The mangled alias is reserved for the genuinely-shadowed case. Follow-up on consolidating this into ``ImportManager`` is tracked at #51.

Tests: new coverage for in-function bare AnnAssign, in-method bare AnnAssign, and try/except/else/finally recursion. Existing "typing-alias-kept-when-aliased-import" and
"typing-alias-kept-when-from-import" tests renamed and rewritten to match the natural "plain-typing" behaviour (aliased/from-only forms don't shadow ``typing``; they leave it unbound so we can safely inject). ``_assert_transform`` dedents the expected string first so plain-string f-string templates work alongside the ``_expected(*sections)`` composition style.