### PR TITLE
playground: dropdown to switch retrofy source (dev/released)

### DIFF
--- a/docs/playground/app.js
+++ b/docs/playground/app.js
@@ -36,12 +36,43 @@ const errorMarkField = StateField.define({
 
 const PYODIDE_VERSION = "v0.29.4";
 const RETROFY_INDEX = "https://pelson.github.io/retrofy/simple/";
+const SOURCES = {
+  dev: {
+    label: "Dev (main)",
+    index_urls: [RETROFY_INDEX, "https://pypi.org/simple/"],
+    pre: true,
+  },
+  released: {
+    label: "Released (PyPI)",
+    index_urls: ["https://pypi.org/simple/"],
+    pre: false,
+  },
+};
 
 const statusEl = document.getElementById("status");
 
 function setStatus(text, cls = "") {
   statusEl.textContent = text;
   statusEl.className = cls;
+}
+
+async function installRetrofy(pyodide, source, { force = false } = {}) {
+  const { label, index_urls, pre } = SOURCES[source];
+  setStatus(`Installing retrofy — ${label}…`);
+  const micropip = pyodide.pyimport("micropip");
+  if (force) {
+    pyodide.runPython(
+      "import sys\n" +
+      "for _m in [m for m in sys.modules if m == 'retrofy' or m.startswith('retrofy.')]:\n" +
+      "    del sys.modules[_m]\n",
+    );
+  }
+  await micropip.install(
+    "retrofy",
+    { index_urls, reinstall: force, pre },
+  );
+  pyodide.runPython("from retrofy._converters import convert");
+  setStatus("Ready.", "ready");
 }
 
 async function bootPyodide() {
@@ -52,17 +83,12 @@ async function bootPyodide() {
   const pyodide = await loadPyodide({
     indexURL: `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full/`,
   });
-  setStatus("Installing retrofy…");
   await pyodide.loadPackage("micropip");
-  const micropip = pyodide.pyimport("micropip");
-  await micropip.install(
-    "retrofy",
-    { index_urls: [RETROFY_INDEX, "https://pypi.org/simple/"] },
-  );
-  pyodide.runPython("from retrofy._converters import convert");
-  setStatus("Ready.", "ready");
+  await installRetrofy(pyodide, currentSource);
   return pyodide;
 }
+
+let currentSource = "released";
 
 export const pyodideReady = bootPyodide().catch((err) => {
   setStatus(`Boot failed: ${err.message}`, "error");
@@ -455,6 +481,28 @@ examplesEl.addEventListener("change", () => {
     changes: { from: 0, to: inputView.state.doc.length, insert: code },
   });
   examplesEl.value = "";
+});
+
+const sourceEl = document.getElementById("source");
+sourceEl.value = currentSource;
+sourceEl.addEventListener("change", async () => {
+  const next = sourceEl.value;
+  if (next === currentSource) return;
+  const prev = currentSource;
+  sourceEl.disabled = true;
+  setOverlay("loading", `Installing retrofy — ${SOURCES[next].label}…`);
+  try {
+    const pyodide = await pyodideReady;
+    await installRetrofy(pyodide, next, { force: true });
+    currentSource = next;
+    runConvert(inputView.state.doc.toString());
+  } catch (err) {
+    setStatus(`Install failed: ${err.message}`, "error");
+    setOverlay("error", `Install failed: ${err.message}`);
+    sourceEl.value = prev;
+  } finally {
+    sourceEl.disabled = false;
+  }
 });
 
 window.__playground = { inputView, outputView, pyodideReady };

--- a/docs/playground/index.html
+++ b/docs/playground/index.html
@@ -9,6 +9,13 @@
   <body>
     <div id="topbar">
       <div id="status">Loading…</div>
+      <label id="source-label">
+        retrofy:
+        <select id="source">
+          <option value="released" selected>Released (PyPI)</option>
+          <option value="dev">Dev (main)</option>
+        </select>
+      </label>
       <label id="examples-label">
         Load example:
         <select id="examples">

--- a/docs/playground/style.css
+++ b/docs/playground/style.css
@@ -4,8 +4,9 @@ body { display: flex; flex-direction: column; }
 #status { padding: 4px 8px; flex: 1; }
 #status.ready { background: #063; }
 #status.error { background: #822; }
-#examples-label { display: flex; align-items: center; padding: 0 8px; gap: 6px; background: #333; }
-#examples { background: #111; color: #ddd; border: 1px solid #555; padding: 2px 4px; font: 12px monospace; }
+#examples-label, #source-label { display: flex; align-items: center; padding: 0 8px; gap: 6px; background: #333; }
+#examples, #source { background: #111; color: #ddd; border: 1px solid #555; padding: 2px 4px; font: 12px monospace; }
+#source:disabled { opacity: 0.6; }
 
 main { display: flex; flex: 1; min-height: 0; }
 .col { display: flex; flex-direction: column; flex: 1 1 0; min-width: 0; overflow: hidden; }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ include = ["retrofy", "retrofy.*"]
 
 [tool.setuptools_scm]
 write_to = "retrofy/_version.py"
+local_scheme = "no-local-version"
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
Adds a source select in the topbar. Reinstalling in-page via micropip with reinstall=True and a purge of cached retrofy* modules lets the running Pyodide session flip between the PyPI release (default) and the main-branch dev index without a browser reload.

Two build/resolve fixes fell out of testing this:

* setuptools_scm was emitting ``+g<sha>`` local-version segments on the dev wheel. micropip (like pip against a simple index) refuses to select local-version releases, so the boot install was silently falling through to PyPI. Set ``local_scheme = "no-local-version"``.

* The dev index only carries pre-releases (``0.3.1.devN``), so the dev source passes ``pre=True`` to micropip; released stays pre=False.