### PR TITLE
Fix #54: TYPE_CHECKING stub keeps def body for attribute inference

### DIFF
--- a/retrofy/_transformations/lazy_imports.py
+++ b/retrofy/_transformations/lazy_imports.py
@@ -210,12 +210,13 @@ def _format_type_checking_block(
     runtime_lines: list[str],
 ) -> str:
     """Emit the ``if <placeholder>.TYPE_CHECKING: <real imports>\\n
-    else: <runtime bindings>`` block that mypy needs to resolve
-    lazy-bound names to their real types while keeping runtime
-    laziness.
+    else: <runtime bindings>`` block that type checkers need to
+    resolve lazy-bound names to their real types while keeping
+    runtime laziness.
 
-    The runtime branch is emitted in an ``else`` so mypy never sees
-    the lazy-helper assignment poison the name's type — see issue #45.
+    The runtime branch is emitted in an ``else`` so type checkers
+    never see the lazy-helper assignment poison the name's type — see
+    issue #45.
 
     The header uses a mangled dunder placeholder (not ``typing``)
     because the source hasn't been parsed into a CST yet — we can't
@@ -653,9 +654,9 @@ class _ReifyStripper(cst.CSTTransformer):
     """Replace ``<reify_name>(X)`` calls with the bare ``X`` argument.
 
     Used to build the ``if TYPE_CHECKING:`` clean-stub form of a
-    construct — the stub carries the original names (which mypy
-    resolves via the top-level TYPE_CHECKING re-import) instead of
-    the runtime ``__lazy_reify__(...)`` call.
+    construct — the stub carries the original names (which type
+    checkers resolve via the top-level TYPE_CHECKING re-import)
+    instead of the runtime ``__lazy_reify__(...)`` call.
     """
 
     def __init__(self, reify_name: str) -> None:
@@ -698,9 +699,10 @@ def _def_has_wrapped_annotation(
     ``<reify_name>(X)`` call.
 
     Only annotations are inspected — body-level wraps are not a
-    reason to duplicate the def under ``TYPE_CHECKING`` (mypy accepts
-    ``__lazy_reify__(X)`` at value positions via the generic ``T->T``
-    signature; only annotation slots trip ``[valid-type]``).
+    reason to duplicate the def under ``TYPE_CHECKING`` (type
+    checkers accept ``__lazy_reify__(X)`` at value positions via the
+    generic ``T->T`` signature; only annotation slots trip
+    ``[valid-type]``).
     """
     params = def_node.params
     for p in (
@@ -744,21 +746,34 @@ def _annassign_has_wrap(
     return False
 
 
+_TYPE_CHECKING_MIRROR_COMMENT_LINES = (
+    "# retrofy: type-checking mirror of the def below; body is",
+    "# duplicated so type checkers see attribute assignments etc.",
+)
+
+
 def _stub_from_def(
     def_node: cst.FunctionDef,
     reify_name: str,
 ) -> cst.FunctionDef:
-    """Build the ``if TYPE_CHECKING:`` stub form of *def_node*: strip
-    reify calls out of annotations and replace the body with an inline
-    ``...`` (single-line ``def f(...) -> T: ...`` — matches the
-    convention for stubs in ``.pyi`` files).
+    """Build the ``if TYPE_CHECKING:`` mirror of *def_node*.
+
+    Strip reify calls throughout (so annotations are clean for type
+    checkers), and keep the original body intact — a bare ``...``
+    stub would hide attribute assignments (``self._x = x`` inside
+    ``__init__``, etc.) and downstream ``[attr-defined]`` errors
+    would follow. See retrofy#54. A leading comment inside the
+    ``TYPE_CHECKING`` branch flags the duplication so a reader
+    doesn't wonder why the def appears twice.
     """
     stripped = def_node.visit(_ReifyStripper(reify_name))
     assert isinstance(stripped, cst.FunctionDef)
+    comment_lines = tuple(
+        cst.EmptyLine(comment=cst.Comment(text))
+        for text in _TYPE_CHECKING_MIRROR_COMMENT_LINES
+    )
     return stripped.with_changes(
-        body=cst.SimpleStatementSuite(
-            body=[cst.Expr(value=cst.Ellipsis())],
-        ),
+        leading_lines=comment_lines + tuple(stripped.leading_lines),
     )
 
 
@@ -813,8 +828,9 @@ def _duplicate_annotated_constructs(
     """Phase 2b: walk module and class bodies, replacing each
     annotation-carrying construct whose annotation contains a
     ``<reify>`` wrap with an ``if <tc>.TYPE_CHECKING: <clean stub>``
-    / ``else: <wrapped>`` pair. This gives mypy a clean signature to
-    read from the ``if`` branch while runtime executes the ``else``
+    / ``else: <wrapped>`` pair. This gives type checkers a clean
+    signature to read from the ``if`` branch while runtime executes
+    the ``else``
     branch's wrapped form (which reifies proxies at eval time so
     ``typing.get_type_hints`` / ``inspect.signature`` see the real
     class rather than a ``LazyProxy``).

--- a/retrofy/tests/test_lazy_imports.py
+++ b/retrofy/tests/test_lazy_imports.py
@@ -224,7 +224,7 @@ def test_lazy_from_single_name() -> None:
 def test_lazy_from_multiple_names_with_alias() -> None:
     # Module-level annotations touching lazy names are wrapped with
     # ``__lazy_reify__(...)`` at runtime AND duplicated under a
-    # ``if TYPE_CHECKING:`` clean stub so mypy sees the unwrapped
+    # ``if TYPE_CHECKING:`` clean stub so type checkers see the unwrapped
     # form (issue #45 phase 2b).
     _assert_transform(
         """
@@ -532,13 +532,22 @@ def test_lazy_modules_warning_with_lazy_keyword_still_rewrites() -> None:
     assert '__lazy_modules__ = {"os"}' in out
 
 
+_TC_MIRROR_COMMENT = (
+    "# retrofy: type-checking mirror of the def below; body is",
+    "# duplicated so type checkers see attribute assignments etc.",
+)
+
+
 def test_function_def_annotation_wrapped_with_type_checking_stub() -> None:
     # Regression coverage for issue #45. A function def whose
     # annotations touch a lazy name is duplicated: the ``if
-    # TYPE_CHECKING:`` branch carries the clean signature that mypy
-    # reads; the ``else:`` branch carries the runtime signature with
-    # ``__lazy_reify__(...)`` wraps, so ``typing.get_type_hints`` gets
-    # the reified real class at introspection time.
+    # TYPE_CHECKING:`` branch carries the clean signature that type
+    # checkers read; the ``else:`` branch carries the runtime
+    # signature with ``__lazy_reify__(...)`` wraps, so
+    # ``typing.get_type_hints`` gets the reified real class at
+    # introspection time. Both branches carry the full body — the
+    # stub form isn't ``...`` because that would hide attribute
+    # assignments inside methods (see retrofy#54).
     _assert_transform(
         """
         from __future__ import annotations
@@ -562,7 +571,10 @@ def test_function_def_annotation_wrapped_with_type_checking_stub() -> None:
             ),
             "",
             _block(
-                ["def do_it(x: typing.Optional[Foo]) -> Foo: ..."],
+                [
+                    *_TC_MIRROR_COMMENT,
+                    "def do_it(x: typing.Optional[Foo]) -> Foo: ...",
+                ],
                 [
                     "def do_it(x: typing.Optional[__lazy_reify__(Foo)]) -> __lazy_reify__(Foo): ...",
                 ],
@@ -575,10 +587,9 @@ def test_function_def_annotation_wrapped_with_type_checking_stub() -> None:
 
 
 def test_body_wrap_kept_alongside_type_checking_stub() -> None:
-    # Runtime uses in the function body still get wrapped — the stub
-    # in the ``if TYPE_CHECKING:`` branch is a bare ``...``, so the
-    # body only appears in the ``else:`` branch and doesn't need a
-    # clean form.
+    # Runtime uses in the function body get ``__lazy_reify__(...)``
+    # wraps; the ``if TYPE_CHECKING:`` mirror strips those wraps back
+    # out so type checkers see the plain body.
     _assert_transform(
         """
         from __future__ import annotations
@@ -598,7 +609,11 @@ def test_body_wrap_kept_alongside_type_checking_stub() -> None:
             ),
             "",
             _block(
-                ["def do_it(x: Foo) -> Foo: ..."],
+                [
+                    *_TC_MIRROR_COMMENT,
+                    "def do_it(x: Foo) -> Foo:",
+                    "    return Foo()",
+                ],
                 [
                     "def do_it(x: __lazy_reify__(Foo)) -> __lazy_reify__(Foo):",
                     "    return __lazy_reify__(Foo)()",
@@ -611,7 +626,7 @@ def test_body_wrap_kept_alongside_type_checking_stub() -> None:
 def test_module_level_annassign_is_type_checking_paired() -> None:
     # Bare module-level ``x: Foo`` also duplicates so the annotation
     # dict contains the real class at runtime (via the wrapped else
-    # branch) and mypy sees the clean form in the if branch.
+    # branch) and type checkers see the clean form in the if branch.
     _assert_transform(
         """
         lazy from typing import List
@@ -784,7 +799,7 @@ def test_in_function_bare_annassign_is_type_checking_paired() -> None:
     # declare a variable's type before a conditional assign) also
     # needs the TYPE_CHECKING/else pair. Otherwise phase 2's
     # ``__lazy_reify__(Foo)`` wrap ends up in the annotation slot
-    # and mypy rejects it with ``[valid-type]``.
+    # and type checkers reject it with ``[valid-type]``.
     _assert_transform(
         """
         lazy from some_pkg import Foo
@@ -837,6 +852,49 @@ def test_in_method_bare_annassign_is_type_checking_paired() -> None:
                 else:
                     z: __lazy_reify__(Foo)
                 del z
+        """,
+    )
+
+
+def test_type_checking_stub_keeps_def_body_for_attribute_inference() -> None:
+    # Retrofy#54: when the ``TYPE_CHECKING`` stub replaces a def's
+    # body with ``...``, type checkers lose sight of every attribute
+    # assigned in the body (e.g. ``self._x = x`` inside ``__init__``)
+    # — even attributes unrelated to any lazy-bound name, like
+    # ``self._y = 42``, become ``[attr-defined]`` at every read.
+    #
+    # Fix: the stub form is a full body duplicate with reify calls
+    # stripped throughout. Type checkers see the assignments and can
+    # infer attribute types normally. A leading comment inside the
+    # ``TYPE_CHECKING`` block flags the duplication so a reader
+    # doesn't wonder why the def appears twice.
+    _assert_transform(
+        """
+        lazy from somepkg import Foo
+
+        class Cls:
+            def __init__(self, x: Foo) -> None:
+                self._x = x
+                self._y = 42
+        """,
+        f"""
+        {_RUNTIME_IMPORT}
+        if typing.TYPE_CHECKING:
+            from somepkg import Foo
+        else:
+            Foo = __lazy_from__('somepkg', 'Foo', 'Foo')
+
+        class Cls:
+            if typing.TYPE_CHECKING:
+                # retrofy: type-checking mirror of the def below; body is
+                # duplicated so type checkers see attribute assignments etc.
+                def __init__(self, x: Foo) -> None:
+                    self._x = x
+                    self._y = 42
+            else:
+                def __init__(self, x: __lazy_reify__(Foo)) -> None:
+                    self._x = x
+                    self._y = 42
         """,
     )
 


### PR DESCRIPTION
Before: the ``if TYPE_CHECKING:`` def body was replaced with an inline ``...``. That hid ``self.<attr> = ...`` assignments inside ``__init__`` (and any other body-level definitions) from type checkers, so every downstream attribute access became ``[attr-defined]`` — including attributes whose type didn't touch any lazy-bound name.

Now the stub form keeps the whole body verbatim, with reify calls stripped throughout by ``_ReifyStripper``. The stub carries a leading comment inside the ``TYPE_CHECKING`` block so a reader can see at a glance that the def is duplicated for type-checking purposes:

    class Cls:
        if typing.TYPE_CHECKING:
            # retrofy: type-checking mirror of the def below; body is
            # duplicated so type checkers see attribute assignments etc.
            def __init__(self, x: Foo) -> None:
                self._x = x
                self._y = 42
        else:
            def __init__(self, x: __lazy_reify__(Foo)) -> None:
                self._x = x
                self._y = 42

Type checkers pick the ``if`` branch and see both assignments, inferring ``Cls._x`` as ``Foo`` (via the clean annotation) and ``Cls._y`` as ``int`` (via the literal). Runtime executes the ``else`` branch with the wrap intact.

Closes 54.