### PR TITLE
playground: install retrofy dev correctly (kwargs, uninstall, libcst)

### DIFF
--- a/docs/playground/app.js
+++ b/docs/playground/app.js
@@ -59,20 +59,37 @@ function setStatus(text, cls = "") {
 async function installRetrofy(pyodide, source, { force = false } = {}) {
   const { label, index_urls, pre } = SOURCES[source];
   setStatus(`Installing retrofy — ${label}…`);
-  const micropip = pyodide.pyimport("micropip");
-  if (force) {
-    pyodide.runPython(
-      "import sys\n" +
-      "for _m in [m for m in sys.modules if m == 'retrofy' or m.startswith('retrofy.')]:\n" +
-      "    del sys.modules[_m]\n",
-    );
-  }
-  await micropip.install(
-    "retrofy",
-    { index_urls, reinstall: force, pre },
-  );
-  pyodide.runPython("from retrofy._converters import convert");
-  setStatus("Ready.", "ready");
+  // Drive the install from Python so kwargs semantics are unambiguous
+  // (JS -> PyProxy call semantics for kwargs are subtle and were
+  // previously swallowing index_urls/pre/reinstall). Uninstall first
+  // when switching sources so ``reinstall`` doesn't just re-fetch the
+  // already-resolved version instead of re-resolving from a new index.
+  const script = `
+import micropip
+_index_urls = ${JSON.stringify(index_urls)}
+_pre = ${pre ? "True" : "False"}
+_force = ${force ? "True" : "False"}
+if _force:
+    import sys
+    for _m in [m for m in sys.modules if m == 'retrofy' or m.startswith('retrofy.')]:
+        del sys.modules[_m]
+    try:
+        micropip.uninstall('retrofy')
+    except Exception:
+        pass
+await micropip.install(
+    'retrofy',
+    index_urls=_index_urls,
+    pre=_pre,
+    reinstall=_force,
+)
+from retrofy._converters import convert  # noqa: F401
+from retrofy._version import version as _rv
+from importlib.metadata import version as _mv
+f'retrofy {_rv} / libcst {_mv("libcst")}'
+`;
+  const versions = await pyodide.runPythonAsync(script);
+  console.log(`[retrofy playground] ${label}: ${versions}`);
 }
 
 async function bootPyodide() {
@@ -83,7 +100,14 @@ async function bootPyodide() {
   const pyodide = await loadPyodide({
     indexURL: `https://cdn.jsdelivr.net/pyodide/${PYODIDE_VERSION}/full/`,
   });
-  await pyodide.loadPackage("micropip");
+  // Load libcst from Pyodide's own emscripten wheel bundle (1.6.0 in
+  // Pyodide 0.29.4). If we don't, micropip resolves retrofy's ``libcst``
+  // dep from PyPI and lands on 0.3.23 — the last pure-Python release,
+  // which predates ``cst.TypeAlias`` and every other PEP 695 node.
+  await pyodide.loadPackage(["micropip", "libcst"], {
+    messageCallback: (msg) => setStatus(`Loading packages: ${msg}`),
+    errorCallback: (msg) => setStatus(`Loading packages: ${msg}`, "error"),
+  });
   await installRetrofy(pyodide, currentSource);
   return pyodide;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license = "Apache-2.0"
 
 # The core dependencies of the project.
 dependencies = [
-  "libcst",
+  "libcst>=1.1",  # cst.TypeAlias / TypeParam / TypeVar (PEP 695) landed in 1.1.0
   "setuptools-ext",  # TODO: Get rid of this dependency when there is a wheel interface elsewhere.
   "tomli; python_version < '3.11'",
   "tomlkit",


### PR DESCRIPTION
Three overlapping bugs were causing the Dev-source selector to appear to do nothing:

- ``micropip.install("retrofy", {index_urls, pre, reinstall})`` from JS silently dropped every option — Pyodide does not destructure a JS object into Python kwargs, so ``{...}`` landed as the ``keep_going`` positional and micropip did a vanilla PyPI install. Driving the install from ``runPythonAsync`` sidesteps that.
- ``reinstall=True`` alone doesn't re-resolve, it just refetches the already-pinned version. Uninstall retrofy first when switching sources so the new ``index_urls``/``pre`` are actually consulted.
- micropip resolved the transitive ``libcst`` dep from PyPI and landed on 0.3.23 (last pure-Python release, predates PEP 695), so ``cst.TypeAlias`` blew up on every convert. Load ``libcst`` from Pyodide's own emscripten wheel bundle (1.6.0 in 0.29.4) before installing retrofy; add ``libcst>=1.1`` as a defence-in-depth floor in pyproject so future regressions fail loudly instead of silently downgrading.

Also route ``loadPackage`` progress into the status pill, and log the installed retrofy + libcst versions to the console so silent-fallback is visible instead of surfacing as a spurious ``SyntaxError`` later.